### PR TITLE
Evaluate any non-string, non-special args in apheleia-formatters

### DIFF
--- a/apheleia.el
+++ b/apheleia.el
@@ -448,7 +448,11 @@ modified from what is written to disk, then don't do anything."
                                   arg))
                               command)))
       (apheleia--make-process
-       :command command
+       :command (mapcar (lambda (arg)
+                          (if (stringp arg)
+                              arg
+                            (eval arg)))
+                        command)
        :stdin (unless input-fname
                 (current-buffer))
        :callback (lambda (stdout)


### PR DESCRIPTION
file, input, and output are special cases in apheleia-formatters that
are specially expanded when interpreted by apheleia-format-buffer.
This commit makes it so any other symbols will be evaluated.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
