### PR TITLE
Add phpcs & introduce scripts/formatters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,20 +15,16 @@ The format is based on [Keep a Changelog].
 
 ### Formatters
 * [dart-format](https://dart.dev/tools/dart-format) for Dart ([#89]).
+* [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) for PHP
+  ([#87]).
 
 ### Features
 * Support remote files and buffers that were opened through TRAMP
   ([#33]).
 
 [#33]: https://github.com/raxod502/apheleia/issues/33
-[#89]: https://github.com/raxod502/apheleia/pull/89
-
-* Support script files defined by apheleia for more troublesome
-  formatters. Resides at `scripts/formatters` and uses `file-truename`
-  to get around package managers that symlink files.
-([#87])
-
 [#87]: https://github.com/raxod502/apheleia/pull/87
+[#89]: https://github.com/raxod502/apheleia/pull/89
 
 ## 2.0
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ The format is based on [Keep a Changelog].
 
 [#33]: https://github.com/raxod502/apheleia/issues/33
 
+* Support script files defined by apheleia for more troublesome
+  formatters. Resides at `scripts/formatters` and uses `file-truename`
+  to get around package managers that symlink files.
+([#87])
+
+[#87]: https://github.com/raxod502/apheleia/pull/87
+
 ## 2.0
 ### Breaking changes
 * The interface to `apheleia-format-buffer` has changed. You now pass

--- a/apheleia.el
+++ b/apheleia.el
@@ -6,7 +6,7 @@
 ;; Created: 7 Jul 2019
 ;; Homepage: https://github.com/raxod502/apheleia
 ;; Keywords: tools
-;; Package-Requires: ((emacs "27.1"))
+;; Package-Requires: ((emacs "26"))
 ;; SPDX-License-Identifier: MIT
 ;; Version: 2.0
 

--- a/apheleia.el
+++ b/apheleia.el
@@ -976,10 +976,11 @@ inside node_modules/.bin if such a directory exists anywhere
 above the current `default-directory'.
 
 The \"scripts/formatters\" subdirectory of the Apheleia source
-repository is automatically prepended to `exec-path' when
-invoking external formatters. This is intended for internal use.
-If you would like to define your own script, you can simply place
-it on your normal $PATH rather than using this system."
+repository is automatically prepended to $PATH (variable
+`exec-path', to be specific) when invoking external formatters.
+This is intended for internal use. If you would like to define
+your own script, you can simply place it on your normal $PATH
+rather than using this system."
   :type '(alist
           :key-type symbol
           :value-type

--- a/apheleia.el
+++ b/apheleia.el
@@ -937,9 +937,7 @@ being run, for diagnostic purposes."
     (terraform . ("terraform" "fmt" "-")))
   "Alist of code formatting commands.
 The keys may be any symbols you want, and the values are shell
-commands, lists of strings and symbols, or a function symbol. You may
-also pass a script to be included from scripts/formatters from within
-the apheleia repository.
+commands, lists of strings and symbols, or a function symbol.
 
 If the value is a function, the function will be called with
 keyword arguments (see the implementation of
@@ -975,7 +973,13 @@ words, `inplace' is like `input' and `output' together.
 If you use the symbol `npx' as one of the elements of commands,
 then the first string element of the command list is resolved
 inside node_modules/.bin if such a directory exists anywhere
-above the current `default-directory'."
+above the current `default-directory'.
+
+The \"scripts/formatters\" subdirectory of the Apheleia source
+repository is automatically prepended to `exec-path' when
+invoking external formatters. This is intended for internal use.
+If you would like to define your own script, you can simply place
+it on your normal $PATH rather than using this system."
   :type '(alist
           :key-type symbol
           :value-type
@@ -1036,7 +1040,8 @@ function: %s" command)))
      (car formatters))))
 
 (defcustom apheleia-mode-alist
-  '((php-mode . phpcs)
+  '(;; php-mode has to come before cc-mode
+    (php-mode . phpcs)
     (cc-mode . clang-format)
     (c-mode . clang-format)
     (c++-mode . clang-format)

--- a/scripts/formatters/apheleia-phpcs
+++ b/scripts/formatters/apheleia-phpcs
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+phpcbf "$@"
+if [ $? -eq 1 ]; then
+   exit 0
+fi

--- a/scripts/formatters/apheleia-phpcs
+++ b/scripts/formatters/apheleia-phpcs
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 phpcbf "$@"
-if [ $? -eq 1 ]; then
+if [ "$?" -eq 1 ]; then
    exit 0
 fi

--- a/test/formatters/apheleia-ft.el
+++ b/test/formatters/apheleia-ft.el
@@ -216,7 +216,16 @@ environment variable, defaulting to all formatters."
             (default-directory temporary-file-directory)
             (exit-status nil)
             (out-file (replace-regexp-in-string
-                       "/in\\([^/]+\\)" "/out\\1" in-file 'fixedcase)))
+                       "/in\\([^/]+\\)" "/out\\1" in-file 'fixedcase))
+            (exec-path
+                (append `(,(expand-file-name
+                            "scripts/formatters"
+                            (file-name-directory
+                             (file-truename
+                              ;; Borrowed with love from Magit
+                              (let ((load-suffixes '(".el")))
+                                (locate-library "apheleia"))))))
+                        exec-path)))
         (mapc
          (lambda (arg)
            (when (memq arg '(file filepath input output inplace))

--- a/test/formatters/installers/phpcs.bash
+++ b/test/formatters/installers/phpcs.bash
@@ -1,0 +1,1 @@
+apt-get install -y php-codesniffer

--- a/test/formatters/samplecode/phpcs/in.php
+++ b/test/formatters/samplecode/phpcs/in.php
@@ -1,0 +1,5 @@
+<?php
+
+if(true)
+{
+    echo 'Hello World';}

--- a/test/formatters/samplecode/phpcs/out.php
+++ b/test/formatters/samplecode/phpcs/out.php
@@ -1,0 +1,5 @@
+<?php
+
+if(true) {
+    echo 'Hello World';
+}


### PR DESCRIPTION
Add phpcs as a supported formatter. 

Currently exists an issue related to `derived-mode-p` because `php-mode` derives from `c-mode` and thus tries to use `clang-format` instead. I'm happy to work through that, but I've made this now to try and get a review going (maybe if someone else would know how to resolve quicker than me too).

I've had to make a potentially large change to add support for exit statuses to be ignored, see [here](https://github.com/squizlabs/PHP_CodeSniffer/issues/1818#issuecomment-354420927) for how they're handled in phpcs. It might also apply for future formatters, so I opted to make a general solution rather than monkey-patch a phpcs-only solution. Because I don't know the potential drawbacks of this change, I've left out amending the CHANGELOG so I can correctly document if it's a breaking change or not.

Feedback welcome, tests pass on my end fine so hopefully also run in CI.