### PR TITLE
Only process when there is output to return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ The format is based on [Keep a Changelog].
 * Formatters using `'filepath` (OCamlFormat and Prettier) are no
   longer prevented from running on a modified buffer ([#109], [#110]).
 
+### Bugs fixed
+* When a formatter has a bug and fails to return anything on stdout
+  (e.g. scalafmt), do not erase the buffer ([#116]).
+
 ### Formatters
 * [bean-format](https://github.com/beancount/beancount) for Beancount
   ([#101]).
@@ -18,6 +22,7 @@ The format is based on [Keep a Changelog].
 [#105]: https://github.com/radian-software/apheleia/pull/105
 [#109]: https://github.com/radian-software/apheleia/issues/109
 [#110]: https://github.com/radian-software/apheleia/pull/110
+[#116]: https://github.com/radian-software/apheleia/pull/116
 
 ## 3.0 (released 2022-06-01)
 ### Breaking changes

--- a/apheleia.el
+++ b/apheleia.el
@@ -1030,13 +1030,14 @@ function: %s" command)))
      buffer
      remote
      (lambda (stdout)
-       (if (cdr formatters)
-           ;; Forward current stdout to remaining formatters, passing along
-           ;; the current callback and using the current formatters output
-           ;; as stdin.
-           (apheleia--run-formatters
-            (cdr formatters) buffer remote callback stdout)
-         (funcall callback stdout)))
+       (unless (string-empty-p (with-current-buffer stdout (buffer-string)))
+         (if (cdr formatters)
+             ;; Forward current stdout to remaining formatters, passing along
+             ;; the current callback and using the current formatters output
+             ;; as stdin.
+             (apheleia--run-formatters
+              (cdr formatters) buffer remote callback stdout)
+           (funcall callback stdout))))
      stdin
      (car formatters))))
 


### PR DESCRIPTION
scalafmt only returns stdout when there are errors, this could also help
in other cases where a formatter returns incorrectly.

Ideally, this would also be improved by basic error checking heuristics
to work out if we need to update the buffer.