### PR TITLE
Use :connection-type pipe when creating local processes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog].
 * shfmt uses 4 spaces instead of tabs by default.
 * Formatters using `'filepath` (OCamlFormat and Prettier) are no
   longer prevented from running on a modified buffer ([#109], [#110]).
+* Buffer content is now always passed to formatters using a pipe. This
+  fixes issues with formatters that behave differently when receiving
+  input on stdin versus being run on a tty.
 
 ### Formatters
 * [bean-format](https://github.com/beancount/beancount) for Beancount

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog].
   longer prevented from running on a modified buffer ([#109], [#110]).
 * Buffer content is now always passed to formatters using a pipe. This
   fixes issues with formatters that behave differently when receiving
-  input on stdin versus being run on a tty.
+  input on stdin versus being run on a tty ([#119]).
 
 ### Formatters
 * [bean-format](https://github.com/beancount/beancount) for Beancount
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog].
 [#105]: https://github.com/radian-software/apheleia/pull/105
 [#109]: https://github.com/radian-software/apheleia/issues/109
 [#110]: https://github.com/radian-software/apheleia/pull/110
+[#119]: https://github.com/radian-software/apheleia/pull/119
 
 ## 3.0 (released 2022-06-01)
 ### Breaking changes

--- a/apheleia.el
+++ b/apheleia.el
@@ -309,7 +309,7 @@ at once.")
 This points into a log buffer.")
 
 (cl-defun apheleia--make-process
-    (&key name stdin stdout stderr command remote noquery callback)
+    (&key name stdin stdout stderr command remote noquery connection-type callback)
   "Helper to run a formatter process asynchronously.
 This starts a formatter process using COMMAND and then connects STDIN,
 STDOUT and STDERR buffers to the processes different streams. Once the
@@ -326,6 +326,7 @@ See `make-process' for a description of the NAME and NOQUERY arguments."
           :command command
           :file-handler remote
           :noquery noquery
+          :connection-type connection-type
           :sentinel
           (lambda (proc _event)
             (unless (process-live-p proc)
@@ -344,7 +345,7 @@ See `make-process' for a description of the NAME and NOQUERY arguments."
     proc))
 
 (cl-defun apheleia--call-process
-    (&key name stdin stdout stderr command remote noquery callback)
+    (&key name stdin stdout stderr command remote noquery connection-type callback)
   "Helper to synchronously run a formatter process.
 This function essentially runs COMMAND synchronously passing STDIN
 as standard input and saving output to the STDOUT and STDERR buffers.
@@ -352,9 +353,9 @@ Once the process is finished CALLBACK will be invoked with the exit
 code (see `process-exit-status') of the process.
 
 This function accepts all the same arguments as `apheleia--make-process'
-for simplicity, however some may not be used. This includes: NAME, and
-NO-QUERY."
-  (ignore name noquery)
+for simplicity, however some may not be used. This includes: NAME,
+NO-QUERY, and CONNECTION-TYPE."
+  (ignore name noquery connection-type)
   (let* ((run-on-remote (and (eq apheleia-remote-algorithm 'remote)
                              remote))
          (stderr-file (apheleia--make-temp-file run-on-remote "apheleia"))
@@ -470,6 +471,7 @@ spawned on remote machines."
                  :stderr stderr
                  :command command
                  :remote remote
+                 :connection-type 'pipe
                  :noquery t
                  :callback
                  (lambda (proc-exit-status)

--- a/apheleia.el
+++ b/apheleia.el
@@ -309,7 +309,8 @@ at once.")
 This points into a log buffer.")
 
 (cl-defun apheleia--make-process
-    (&key name stdin stdout stderr command remote noquery connection-type callback)
+    (&key name stdin stdout stderr command
+          remote noquery connection-type callback)
   "Helper to run a formatter process asynchronously.
 This starts a formatter process using COMMAND and then connects STDIN,
 STDOUT and STDERR buffers to the processes different streams. Once the
@@ -345,7 +346,8 @@ See `make-process' for a description of the NAME and NOQUERY arguments."
     proc))
 
 (cl-defun apheleia--call-process
-    (&key name stdin stdout stderr command remote noquery connection-type callback)
+    (&key name stdin stdout stderr command
+          remote noquery connection-type callback)
   "Helper to synchronously run a formatter process.
 This function essentially runs COMMAND synchronously passing STDIN
 as standard input and saving output to the STDOUT and STDERR buffers.


### PR DESCRIPTION
This is helpful because some formatters, rather than having an option
to enable reading from stdin, simply check whether their input comes
from a pipe or terminal. I don't really think this is a wise thing for any code formatter/application to do, but unfortunately it seems somewhat widespread, so we should support it.

In particular, this fixes prettier, so should close #118.

I hope this suits you code and documentation-style wise, wasn't really how to best handle adding a new but non-changing `make-process` argument with the keyword-argument forwarding the existing code does.