### PR TITLE
Use inplace formatter output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog].
 * clang-format doesn't handle filenames correctly by default. Support
   for guessing the flags from first the file name then the major mode
   in the case of a temporary buffer was added in [#128]
+* Fix handling of formatters using `inplace` in some circumstances
+  ([#132]).
 
 ### Formatters
 * [elm-format](https://github.com/avh4/elm-format) for Elm ([#100]).
@@ -64,6 +66,7 @@ The format is based on [Keep a Changelog].
 [#126]: https://github.com/radian-software/apheleia/pull/126
 [#127]: https://github.com/radian-software/apheleia/pull/127
 [#128]: https://github.com/radian-software/apheleia/pull/128
+[#132]: https://github.com/radian-software/apheleia/pull/132
 
 ## 3.0 (released 2022-06-01)
 ### Breaking changes

--- a/apheleia.el
+++ b/apheleia.el
@@ -803,11 +803,11 @@ machine from the machine file is available on"))
         (let ((input-fname (apheleia--strip-remote input-fname)))
           (setq command (mapcar (lambda (arg)
                                   (if (memq arg '(input inplace))
-                                      input-fname
+                                      (progn
+                                        (setq output-fname input-fname)
+                                        input-fname)
                                     arg))
-                                command)))
-        (when (memq 'inplace command)
-          (setq output-fname input-fname)))
+                                command))))
       (when (memq 'output command)
         (setq output-fname (apheleia--make-temp-file run-on-remote "apheleia"))
         (let ((output-fname (apheleia--strip-remote output-fname)))
@@ -871,9 +871,9 @@ purposes."
            (lambda (stdout)
              (when output-fname
                ;; Load output-fname contents into the stdout buffer.
-               (erase-buffer)
-               (insert-file-contents-literally output-fname))
-
+               (with-current-buffer stdout
+                 (erase-buffer)
+                 (insert-file-contents-literally output-fname)))
              (funcall callback stdout))
            :ensure
            (lambda ()


### PR DESCRIPTION
When formatting command is defined with symbol `inplace`, it doesn't work.

I'm using [casey/just](https://github.com/casey/just) (v1.5.0).

It doesn't support formatting of `stdin`, but it supports in-place formatting with command `just --unstable --fmt --justfile /tmp/justfile`. So I've added a list to to `apheleia-formatters` custom variable:

```elisp
(add-to-list 'apheleia-formatters
             '(just . ("just" "--unstable" "--fmt" "--justfile" inplace))
             "APPEND:non-nil")
```

Minimal `justfile` before formatting (there is one space before `echo`):
```make
rule:
 echo test
```

Expected formatting result (there are four spaces before `echo`):
```make
rule:
    echo test
```

Without this pull request there are no visible changes after <kbd>C-u</kbd> <kbd>M-x</kbd> `apheleia-format-buffer` <kbd>RET</kbd> `just` <kbd>RET</kbd>. When this pull request is applied, formatting proceed as expected.