### PR TITLE
Use cargo to run rustfmt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog].
   in the case of a temporary buffer was added in [#128]
 * Fix handling of formatters using `inplace` in some circumstances
   ([#132]).
+* Use `cargo fmt` to format Rust code to support Rust editions ([#140]).
 
 ### Formatters
 * [elm-format](https://github.com/avh4/elm-format) for Elm ([#100]).

--- a/apheleia.el
+++ b/apheleia.el
@@ -983,7 +983,7 @@ being run, for diagnostic purposes."
      . (npx "prettier" "--stdin-filepath" filepath "--parser=yaml"))
     (shfmt . ("shfmt" "-i" "4"))
     (stylua . ("stylua" "-"))
-    (rustfmt . ("rustfmt" "--quiet" "--emit" "stdout"))
+    (rustfmt . ("cargo" "fmt" "--" "--quiet" "--emit" "stdout"))
     (terraform . ("terraform" "fmt" "-")))
   "Alist of code formatting commands.
 The keys may be any symbols you want, and the values are shell


### PR DESCRIPTION
While attempting to format Rust code that uses async functions and new syntax, apheleia runs `rustfmt` without an edition specified, which causes an error. This change uses `cargo fmt` instead, which uses the configured Rust edition from the `Cargo.toml` file to invoke rustfmt.

This is the error I was getting before the change:

```
$ rustfmt --quiet --emit stdout

error[E0670]: `async fn` is not permitted in Rust 2015
 --> <stdin>:5:1
  |
5 | async fn main() -> Result<(), Box<dyn std::error::Error>> {
  | ^^^^^ to use `async fn`, switch to Rust 2018 or later
  |
  = help: pass `--edition 2021` to `rustc`
  = note: for more on editions, read https://doc.rust-lang.org/edition-guide

error: expected one of `!`, `)`, `,`, `.`, `::`, `?`, `{`, or an operator, found keyword `move`
  --> <stdin>:11:21
   |
11 |     tokio::spawn(async move {
   |                        ^^^^ expected one of 8 possible tokens

Command failed with exit code 1.
```