### PR TITLE
Avoid overwriting apheleia-formatters for npx commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog].
   succession, its contents could be erased and replaced with an error
   message from the formatter. This has been fixed. See [#131] for more
   details.
+* Npx commands in apheleia-formatters are not overwritten when
+  expanding binary path to node_modules directory ([#152]).
 
 ### Formatters
 * [`crystal tool
@@ -47,6 +49,7 @@ The format is based on [Keep a Changelog].
 [#145]: https://github.com/radian-software/apheleia/pull/145
 [#147]: https://github.com/radian-software/apheleia/pull/147
 [#148]: https://github.com/radian-software/apheleia/pull/148
+[#152]: https://github.com/radian-software/apheleia/pull/152
 
 ## 3.1 (released 2022-11-11)
 ### Enhancements

--- a/apheleia.el
+++ b/apheleia.el
@@ -760,7 +760,8 @@ cmd is to be run."
            ;; remote.
            (remote-match (equal run-on-remote remote))
            (stdin (or stdin-buffer (current-buffer)))
-           (npx nil))
+           (npx nil)
+           (command (apply #'list command)))
       ;; TODO: Support arbitrary package managers, not just NPM.
       (when (memq 'npx command)
         (setq npx t)


### PR DESCRIPTION
When the formatter is an npx command, setcar is used to expand the
binary file path to node_modules/.bin. But setcar overwrites the
underlying list, so the expanded path is set into
apheleia-formatters. (The list was processed by remq before setcar,
but remq seems to return the cdr if only the first element is
removed.) This is undesirable because when working on multiple NPM
packages, each package may have a formatter of different version.

-------

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->