### PR TITLE
Fix ktlint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Bugs fixed
+* `ktlint` would emit log messages into its stdout when formatting,
+  and these would get spliced into the source file. This has been fixed
+  by suppressing all logs from `ktlint`.
+
 ## 3.2 (released 2023-02-25)
 ### Features
 * You can use `apheleia-inhibit` as a file-local variable to disable

--- a/apheleia.el
+++ b/apheleia.el
@@ -961,7 +961,7 @@ being run, for diagnostic purposes."
     (google-java-format . ("google-java-format" "-"))
     (isort . ("isort" "-"))
     (lisp-indent . apheleia-indent-lisp-buffer)
-    (ktlint . ("ktlint" "--stdin" "-F"))
+    (ktlint . ("ktlint" "--log-level=none" "--stdin" "-F"))
     (latexindent . ("latexindent" "--logfile=/dev/null"))
     (mix-format . ("mix" "format" "-"))
     (nixfmt . ("nixfmt"))


### PR DESCRIPTION
Recent versions of ktlint (mine's 0.48.2) have started including logs in their output when the `--stdin` flag is given. These logs would end up being included *into the file* by apheleia, which isn't what we want.

Since emitting log messages is likely never a good idea when formatting code, I just opted to disable them altogether using a command line flag. This fixes the issue.

This is what it looked like:

![apheleia](https://user-images.githubusercontent.com/15893/224090528-16e8f355-aa80-42ff-9bcc-a8d7894387f7.png)

The exact log message (so people can look it up via search) is this:

```
17:35:12.990 [main] INFO com.pinterest.ktlint.internal.KtlintCommandLine - Enable default patterns [**/*.kt, **/*.kts]
```

I've added a `CHANGELOG` entry, even though I'm unsure it's required. I can delete it, if desired.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
