### PR TITLE
Take `tab-width` into account in `shfmt`

### DIFF
--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -58,7 +58,7 @@
      . (npx "prettier" "--stdin-filepath" filepath "--parser=typescript"))
     (prettier-yaml
      . (npx "prettier" "--stdin-filepath" filepath "--parser=yaml"))
-    (shfmt . ("shfmt" "-i" "4"))
+    (shfmt . ("shfmt" "-i" (number-to-string tab-width)))
     (stylua . ("stylua" "-"))
     (rustfmt . ("rustfmt" "--quiet" "--emit" "stdout"))
     (terraform . ("terraform" "fmt" "-")))


### PR DESCRIPTION
The indentation size of 4 was hard-coded in the formatter parameters. This PR fixes this by using the `tab-width` value. 
