### PR TITLE
feat: add prettier-json-stringify formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog].
 ## Unreleased
 ### Formatters
 * `biome` ([#339]).
+* `prettier-json-stringify` ([#183]).
 
 [#339]: https://github.com/radian-software/apheleia/pull/339
+[#183]: https://github.com/radian-software/apheleia/pull/183
 
 ## 4.3 (released 2024-11-12)
 ### Features

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -129,6 +129,10 @@
      . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
         "--parser=json"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
+    (prettier-json-stringify
+     . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
+        "--parser=json-stringify"
+        (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-markdown
      . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
         "--parser=markdown"

--- a/test/formatters/installers/prettier-json-stringify.bash
+++ b/test/formatters/installers/prettier-json-stringify.bash
@@ -1,0 +1,1 @@
+npm install -g prettier

--- a/test/formatters/samplecode/prettier-json-stringify/in.json
+++ b/test/formatters/samplecode/prettier-json-stringify/in.json
@@ -1,0 +1,13 @@
+{
+  "name": "test-package-json",
+  "version": "1.0.0",
+  "main": "index.js",
+  "files": ["index.js"],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/test/formatters/samplecode/prettier-json-stringify/out.json
+++ b/test/formatters/samplecode/prettier-json-stringify/out.json
@@ -1,0 +1,15 @@
+{
+  "name": "test-package-json",
+  "version": "1.0.0",
+  "main": "index.js",
+  "files": [
+    "index.js"
+  ],
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}


### PR DESCRIPTION
Adds a new formatter for prettier `prettier-json-stringify` which uses prettier `json-stringify` parser. `json-stringify` parser is used by prettier for formatting package.json files