### PR TITLE
docs: fix broken links in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,9 @@ The format is based on [Keep a Changelog].
 [#145]: https://github.com/radian-software/apheleia/pull/145
 [#147]: https://github.com/radian-software/apheleia/pull/147
 [#148]: https://github.com/radian-software/apheleia/pull/148
+[#151]: https://github.com/radian-software/apheleia/pull/151
 [#152]: https://github.com/radian-software/apheleia/pull/152
+[#155]: https://github.com/radian-software/apheleia/pull/155
 
 ## 3.1 (released 2022-11-11)
 ### Enhancements


### PR DESCRIPTION
links for PRs #151 and #155 were broken in the changelog

use the rich view mode in github for better view of the result:
![image](https://user-images.githubusercontent.com/17787042/228892528-888ec39a-8681-4f57-952a-72f512f5d2cd.png)
