### PR TITLE
Add `yapf` formatter

### DIFF
--- a/apheleia.el
+++ b/apheleia.el
@@ -144,7 +144,8 @@
     (rufo . ("rufo" "--filename" filepath "--simple-exit"))
     (stylua . ("stylua" "-"))
     (rustfmt . ("rustfmt" "--quiet" "--emit" "stdout"))
-    (terraform . ("terraform" "fmt" "-")))
+    (terraform . ("terraform" "fmt" "-"))
+    (yapf . ("yapf")))
   "Alist of code formatting commands.
 The keys may be any symbols you want, and the values are shell
 commands, lists of strings and symbols, or a function symbol.

--- a/test/formatters/installers/yapf.bash
+++ b/test/formatters/installers/yapf.bash
@@ -1,0 +1,1 @@
+apt-get install -y python3-yapf

--- a/test/formatters/samplecode/yapf/in.py
+++ b/test/formatters/samplecode/yapf/in.py
@@ -1,0 +1,16 @@
+import sys
+
+import os
+
+
+import path
+
+def the_solution(a, b:int , c:bool=True) ->   bool:
+    print(a+  b)
+
+
+
+    return True
+
+if  __name__  ==  "__main__" :
+    the_solution(1, 2, )

--- a/test/formatters/samplecode/yapf/out.py
+++ b/test/formatters/samplecode/yapf/out.py
@@ -1,0 +1,18 @@
+import sys
+
+import os
+
+import path
+
+
+def the_solution(a, b: int, c: bool = True) -> bool:
+    print(a + b)
+
+    return True
+
+
+if __name__ == "__main__":
+    the_solution(
+        1,
+        2,
+    )


### PR DESCRIPTION
Add [https://github.com/google/yapf](yapf) for python.  I didn't add `yapf` to `apheleia-mode-alist`, because I think `black` more popular.  Message me if I must add it to any other place