### PR TITLE
Use `prettier-json` for `js-json-mode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog].
   respected as before ([#206]).
 
 ### Enhancements
+* Use the `prettier-json` formatter for `js-json-mode`.
 * Prettier is now enabled in `svelte-mode`.
 * More tree-sitter based major modes have been added to
   `apheleia-mode-alist` ([#191]).

--- a/apheleia.el
+++ b/apheleia.el
@@ -250,6 +250,7 @@ rather than using this system."
     (java-mode . google-java-format)
     (java-ts-mode . google-java-format)
     (js3-mode . prettier-javascript)
+    (js-json-mode . prettier-json)
     (js-mode . prettier-javascript)
     (js-ts-mode . prettier-javascript)
     (json-mode . prettier-json)


### PR DESCRIPTION
By default Emacs 29 uses `js-json-mode` for JSON file (correct me if I'm wrong), this pr enables the right formatter for this mode.
