### PR TITLE
Remove go-mod-ts-mode from apheleia-mode-alist

### DIFF
--- a/apheleia.el
+++ b/apheleia.el
@@ -241,7 +241,6 @@ rather than using this system."
     (elm-mode . elm-format)
     (fish-mode . fish-indent)
     (go-mode . gofmt)
-    (go-mod-ts-mode . gofmt)
     (go-ts-mode . gofmt)
     (graphql-mode . prettier-graphql)
     (haskell-mode . brittany)


### PR DESCRIPTION
go-mod-ts-mode is used with go.mod files. These cannot be formatted with gofmt; attempting to do so will lead to an error anyway. Note that also the goimports tool won’t work with go.mod files.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
