### PR TITLE
use up-to-date golang

### DIFF
--- a/test/formatters/install-common.bash
+++ b/test/formatters/install-common.bash
@@ -15,7 +15,7 @@ tee -a /etc/apt/sources.list.d/nodejs.list >/dev/null <<EOF
 deb [arch=amd64] https://deb.nodesource.com/${node_repo} ${ubuntu_name} main
 EOF
 
-add-apt-repository ppa:longsleep/golang-backports
+add-apt-repository -n ppa:longsleep/golang-backports
 
 apt-get update
 

--- a/test/formatters/install-common.bash
+++ b/test/formatters/install-common.bash
@@ -4,7 +4,7 @@ set -euxo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y ca-certificates curl gnupg lsb-release
+apt-get install -y ca-certificates curl gnupg lsb-release software-properties-common
 
 curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
@@ -14,6 +14,8 @@ node_repo="$(curl -fsSL https://deb.nodesource.com/setup_current.x | grep NODERE
 tee -a /etc/apt/sources.list.d/nodejs.list >/dev/null <<EOF
 deb [arch=amd64] https://deb.nodesource.com/${node_repo} ${ubuntu_name} main
 EOF
+
+add-apt-repository ppa:longsleep/golang-backports
 
 apt-get update
 

--- a/test/formatters/installers/gofumpt.bash
+++ b/test/formatters/installers/gofumpt.bash
@@ -1,6 +1,3 @@
-# Require at least version 1.17 of go
-# https://github.com/mvdan/gofumpt/issues/231
-curl -OL https://golang.org/dl/go1.19.3.linux-amd64.tar.gz
-sudo tar -C /usr/local -xvf go1.19.3.linux-amd64.tar.gz
-/usr/local/go/bin/go install mvdan.cc/gofumpt@latest
+apt-get install -y golang-go
+go install mvdan.cc/gofumpt@latest
 cp -L "$HOME/go/bin/gofumpt" /usr/local/bin/

--- a/test/formatters/installers/goimports.bash
+++ b/test/formatters/installers/goimports.bash
@@ -1,3 +1,3 @@
 apt-get install -y golang-go
-go get -u golang.org/x/tools/cmd/goimports
+go install golang.org/x/tools/cmd/goimports@latest
 cp -L "$HOME/go/bin/goimports" /usr/local/bin/


### PR DESCRIPTION
While running a full `make fmt-build`, I got some failures with installer scripts for golang formatters.  This fixes the problem by installing an up-to-date golang instead of the version available in ubuntu 20.04.

The ppa used here, `longsleep/golang-backports` is [recommended](https://github.com/golang/go/wiki/Ubuntu) by the Go project.