### PR TITLE
Use lisp-indent formatter in emacs-lisp-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog].
 * Prettier is now enabled in `svelte-mode`.
 * More tree-sitter based major modes have been added to
   `apheleia-mode-alist` ([#191]).
+* Use `lisp-indent` as default formatter for `emacs-lisp-mode` ([#223])
 
 ### Bugs fixed
 * `ktlint` would emit log messages into its stdout when formatting,

--- a/apheleia.el
+++ b/apheleia.el
@@ -241,6 +241,7 @@ rather than using this system."
     (elixir-mode . mix-format)
     (elixir-ts-mode . mix-format)
     (elm-mode . elm-format)
+    (emacs-lisp-mode . lisp-indent)
     (fish-mode . fish-indent)
     (go-mode . gofmt)
     (go-ts-mode . gofmt)


### PR DESCRIPTION
What it says in the subject :)

Apheleia is opinionated about using a formatter, and which to use as a default, in every other mode it supports, so it seems it should have an opinion about emacs-lisp-mode, too?