### PR TITLE
feat: add filepath to mix-format

### DIFF
--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -72,7 +72,7 @@
     (lisp-indent . apheleia-indent-lisp-buffer)
     (ktlint . ("ktlint" "--log-level=none" "--stdin" "-F" "-"))
     (latexindent . ("latexindent" "--logfile=/dev/null"))
-    (mix-format . ("mix" "format" "-"))
+    (mix-format . ("mix" "format" "--stdin-filename" filepath "-"))
     (nixfmt . ("nixfmt"))
     (ocamlformat . ("ocamlformat" "-" "--name" filepath
                     "--enable-outside-detected-project"))


### PR DESCRIPTION
Allows mix to format files other than elixir or erlang files, e.g. `.heex` files given : 
- [proper formatting directory configuration](https://github.com/radian-software/apheleia/issues/30#issuecomment-778150037)
- [proper mix formatting config](https://hexdocs.pm/phoenix_live_view/Phoenix.LiveView.HTMLFormatter.html#module-setup)

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
