### PR TITLE
Use hclfmt to format hashicorp HCL files.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog].
   `apheleia-mode-alist` ([#191]).
 * Autoload the apheleia-goto-error command ([#215]).
 * Use `lisp-indent` as default formatter for `emacs-lisp-mode` ([#223])
+* Use `hclfmt` for formatting hashicorp HCL files ([#231])
 
 ### Internal Changes
 * Refactored the organisation of the apheleia package for ease of
@@ -71,6 +72,7 @@ The format is based on [Keep a Changelog].
 * [`rufo`](https://github.com/ruby-formatter/rufo) for
   [Ruby](https://www.ruby-lang.org/en/) ([#177]).
 * [`yapf`](https://github.com/google/yapf) for [Python](https://www.python.org/) ([#196])
+* [`hclfmt`](https://github.com/hashicorp/hcl/tree/main/cmd/hclfmt) for [HCL](https://github.com/hashicorp/hcl) ([#231])
 
 [#168]: https://github.com/radian-software/apheleia/pull/168
 [#169]: https://github.com/radian-software/apheleia/pull/169
@@ -91,6 +93,7 @@ The format is based on [Keep a Changelog].
 [#214]: https://github.com/radian-software/apheleia/pull/214
 [#215]: https://github.com/radian-software/apheleia/pull/215
 [#223]: https://github.com/radian-software/apheleia/pull/223
+[#231]: https://github.com/radian-software/apheleia/pull/231
 
 ## 3.2 (released 2023-02-25)
 ### Features

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -50,6 +50,7 @@
     (gofumpt . ("gofumpt"))
     (goimports . ("goimports"))
     (google-java-format . ("google-java-format" "-"))
+    (hclfmt . ("hclfmt"))
     (html-tidy "tidy"
                "--quiet" "yes"
                "--tidy-mark" "no"
@@ -237,6 +238,7 @@ rather than using this system."
     (go-ts-mode . gofmt)
     (graphql-mode . prettier-graphql)
     (haskell-mode . brittany)
+    (hcl-mode . hclfmt)
     (html-mode . prettier-html)
     (html-ts-mode . prettier-html)
     (java-mode . google-java-format)

--- a/test/formatters/installers/hclfmt.bash
+++ b/test/formatters/installers/hclfmt.bash
@@ -1,0 +1,3 @@
+apt-get install -y golang-go
+go install github.com/hashicorp/hcl/v2/cmd/hclfmt@latest
+cp -L "$HOME/go/bin/hclfmt" /usr/local/bin/

--- a/test/formatters/samplecode/hclfmt/in.hcl
+++ b/test/formatters/samplecode/hclfmt/in.hcl
@@ -1,0 +1,9 @@
+block {
+    whatever = 1
+  format = "iam in"
+}
+
+vars = {
+equals = "needs"
+  aligned    = "properly"
+}

--- a/test/formatters/samplecode/hclfmt/out.hcl
+++ b/test/formatters/samplecode/hclfmt/out.hcl
@@ -1,0 +1,9 @@
+block {
+  whatever = 1
+  format   = "iam in"
+}
+
+vars = {
+  equals  = "needs"
+  aligned = "properly"
+}


### PR DESCRIPTION
Add formatter `hclfmt` for Hashicorp Configuration Langauge (HCL).



<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
