### PR TITLE
Always supply `--stdin-filepath` to Prettier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ The format is based on [Keep a Changelog].
   installed locally ([#215]).
 * Fixed clang-format formatter did not respect remote file-name component for
   the assumed file-name ([#215]).
+* Always supply `--stdin-filepath` to Prettier to allow it to pick up
+  the correct settings from project-level config files ([#253]).
 
 ### Formatters
 
@@ -119,6 +121,7 @@ The format is based on [Keep a Changelog].
 [#232]: https://github.com/radian-software/apheleia/issues/232
 [#236]: https://github.com/radian-software/apheleia/pull/236
 [#242]: https://github.com/radian-software/apheleia/pull/242
+[#253]: https://github.com/radian-software/apheleia/pull/253
 
 ## 3.2 (released 2023-02-25)
 ### Features

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -86,26 +86,32 @@
      . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-css
-     . ("apheleia-npx" "prettier" "--parser=css"
+     . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
+        "--parser=css"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-html
-     . ("apheleia-npx" "prettier" "--parser=html"
+     . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
+        "--parser=html"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-graphql
-     . ("apheleia-npx" "prettier" "--parser=graphql"
+     . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
+        "--parser=graphql"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-javascript
-     . ("apheleia-npx" "prettier" "--parser=babel-flow"
+     . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
+        "--parser=babel-flow"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-json
-     . ("apheleia-npx" "prettier" "--parser=json"
+     . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
+        "--parser=json"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-markdown
-     . ("apheleia-npx" "prettier" "--parser=markdown"
+     . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
+        "--parser=markdown"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-ruby
-     . ("apheleia-npx" "prettier" "--stdin-filepath" "dummy.rb"
-        "--plugin=@prettier/plugin-ruby"
+     . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
+        "--plugin=@prettier/plugin-ruby" "--parser=ruby"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-scss
      . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
@@ -113,13 +119,15 @@
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-svelte
      . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
-        "--plugin=prettier-plugin-svelte"
+        "--plugin=prettier-plugin-svelte" "--parser=svelte"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-typescript
-     . ("apheleia-npx" "prettier" "--parser=typescript"
+     . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
+        "--parser=typescript"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (prettier-yaml
-     . ("apheleia-npx" "prettier" "--parser=yaml"
+     . ("apheleia-npx" "prettier" "--stdin-filepath" filepath
+        "--parser=yaml"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (purs-tidy . ("apheleia-npx" "purs-tidy" "format"))
     (rubocop . ("rubocop" "--stdin" filepath "--auto-correct"


### PR DESCRIPTION
This is required for Prettier to pick up the correct settings from its config files.