### PR TITLE
Log an error when a formatter's executable is not found

### DIFF
--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -980,26 +980,25 @@ purposes."
                               (let ((load-suffixes '(".el")))
                                 (locate-library "apheleia"))))))
                         exec-path)))
-      (unless
-          (when (executable-find (apheleia-formatter--arg1 ctx)
-                                 (eq apheleia-remote-algorithm 'remote))
-            (apheleia--execute-formatter-process
-             :ctx ctx
-             :callback
-             (lambda (stdout)
-               (when-let
-                   ((output-fname (apheleia-formatter--output-fname ctx)))
-                 ;; Load output-fname contents into the stdout buffer.
-                 (with-current-buffer stdout
-                   (erase-buffer)
-                   (insert-file-contents-literally output-fname)))
-               (funcall callback stdout))
-             :ensure
-             (lambda ()
-               (dolist (fname (list (apheleia-formatter--input-fname ctx)
-                                    (apheleia-formatter--output-fname ctx)))
-                 (when fname
-                   (ignore-errors (delete-file fname)))))))
+      (if (executable-find (apheleia-formatter--arg1 ctx)
+                           (eq apheleia-remote-algorithm 'remote))
+          (apheleia--execute-formatter-process
+           :ctx ctx
+           :callback
+           (lambda (stdout)
+             (when-let
+                 ((output-fname (apheleia-formatter--output-fname ctx)))
+               ;; Load output-fname contents into the stdout buffer.
+               (with-current-buffer stdout
+                 (erase-buffer)
+                 (insert-file-contents-literally output-fname)))
+             (funcall callback stdout))
+           :ensure
+           (lambda ()
+             (dolist (fname (list (apheleia-formatter--input-fname ctx)
+                                  (apheleia-formatter--output-fname ctx)))
+               (when fname
+                 (ignore-errors (delete-file fname))))))
         (apheleia--log
          'process
          "Could not find executable for formatter %s, skipping" formatter)))))

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -987,7 +987,8 @@ purposes."
              :ctx ctx
              :callback
              (lambda (stdout)
-               (when-let ((output-fname (apheleia-formatter--output-fname ctx)))
+               (when-let
+                   ((output-fname (apheleia-formatter--output-fname ctx)))
                  ;; Load output-fname contents into the stdout buffer.
                  (with-current-buffer stdout
                    (erase-buffer)

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -980,24 +980,28 @@ purposes."
                               (let ((load-suffixes '(".el")))
                                 (locate-library "apheleia"))))))
                         exec-path)))
-      (when (executable-find (apheleia-formatter--arg1 ctx)
-                             (eq apheleia-remote-algorithm 'remote))
-        (apheleia--execute-formatter-process
-         :ctx ctx
-         :callback
-         (lambda (stdout)
-           (when-let ((output-fname (apheleia-formatter--output-fname ctx)))
-             ;; Load output-fname contents into the stdout buffer.
-             (with-current-buffer stdout
-               (erase-buffer)
-               (insert-file-contents-literally output-fname)))
-           (funcall callback stdout))
-         :ensure
-         (lambda ()
-           (dolist (fname (list (apheleia-formatter--input-fname ctx)
-                                (apheleia-formatter--output-fname ctx)))
-             (when fname
-               (ignore-errors (delete-file fname))))))))))
+      (unless
+          (when (executable-find (apheleia-formatter--arg1 ctx)
+                                 (eq apheleia-remote-algorithm 'remote))
+            (apheleia--execute-formatter-process
+             :ctx ctx
+             :callback
+             (lambda (stdout)
+               (when-let ((output-fname (apheleia-formatter--output-fname ctx)))
+                 ;; Load output-fname contents into the stdout buffer.
+                 (with-current-buffer stdout
+                   (erase-buffer)
+                   (insert-file-contents-literally output-fname)))
+               (funcall callback stdout))
+             :ensure
+             (lambda ()
+               (dolist (fname (list (apheleia-formatter--input-fname ctx)
+                                    (apheleia-formatter--output-fname ctx)))
+                 (when fname
+                   (ignore-errors (delete-file fname)))))))
+        (apheleia--log
+         'process
+         "Could not find executable for formatter %s, skipping" formatter)))))
 
 (defun apheleia--run-formatter-function
     (func buffer remote callback stdin formatter)


### PR DESCRIPTION
I was trying to set up a new formatter and it wasn't in my exec-path, so it wasn't running anything. But there was no message in the apheleia logs, even with `apheleia-log-debug-info` enabled. This adds a log entry when the executable is not found.

Hopefully the formatting is okay - I think Apheleia re-indented it so hopefully that's good.

Fixes #268
