### PR TITLE
Extend lua support to lua-ts-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ The format is based on [Keep a Changelog].
 * [docformatter](https://github.com/PyCQA/docformatter) for Python docstrings ([#267])
 * [cljfmt](https://github.com/weavejester/cljfmt) for clojure,
   clojurescript, edn files. ([#271])
+* Stylua is used now in `lua-ts-mode` as well as just `lua-mode`, by
+  default ([#275]).
 
 [#209]: https://github.com/radian-software/apheleia/pull/209
 [#229]: https://github.com/radian-software/apheleia/pull/229
@@ -42,6 +44,7 @@ The format is based on [Keep a Changelog].
 [#264]: https://github.com/radian-software/apheleia/pull/264
 [#267]: https://github.com/radian-software/apheleia/pull/267
 [#271]: https://github.com/radian-software/apheleia/pull/271
+[#275]: https://github.com/radian-software/apheleia/pull/275
 
 ## 4.0 (released 2023-11-23)
 ### Breaking changes

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -333,6 +333,7 @@ rather than using this system."
     (latex-mode . latexindent)
     (LaTeX-mode . latexindent)
     (lua-mode . stylua)
+    (lua-ts-mode . stylua)
     (lisp-mode . lisp-indent)
     ;; markdown-mode not included because so many people format
     ;; markdown code in so many different ways and we don't want to


### PR DESCRIPTION
Available via https://git.sr.ht/~johnmuhl/lua-ts-mode and https://git.savannah.gnu.org/cgit/emacs.git/commit/?id=b6659e98a4fcaa44477b64d7782243feca020418

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
