### PR TITLE
Add `ruff-isort` formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog].
   for JSON ([#257]).
 * [`robotidy`](https://robotidy.readthedocs.io) for Robot Framework files
   ([#263]).
+* [`ruff-isort`](https://github.com/astral-sh/ruff) for [Python](https://python.org) imports using ruff ([#TBD]).
 * [denofmt](https://docs.deno.com/runtime/manual/tools/formatter) for
   js, jsx, ts, tsx, json, jsonc, md files. ([#264])
 * [docformatter](https://github.com/PyCQA/docformatter) for Python docstrings ([#267])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ The format is based on [Keep a Changelog].
   for JSON ([#257]).
 * [`robotidy`](https://robotidy.readthedocs.io) for Robot Framework files
   ([#263]).
-* [`ruff-isort`](https://github.com/astral-sh/ruff) for [Python](https://python.org) imports using ruff ([#TBD]).
+* [`ruff-isort`](https://github.com/astral-sh/ruff) for [Python](https://python.org) imports using ruff ([#279]).
 * [denofmt](https://docs.deno.com/runtime/manual/tools/formatter) for
   js, jsx, ts, tsx, json, jsonc, md files. ([#264])
 * [docformatter](https://github.com/PyCQA/docformatter) for Python docstrings ([#267])
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog].
 [#271]: https://github.com/radian-software/apheleia/pull/271
 [#274]: https://github.com/radian-software/apheleia/issues/274
 [#275]: https://github.com/radian-software/apheleia/pull/275
+[#279]: https://github.com/radian-software/apheleia/pull/279
 
 ## 4.0 (released 2023-11-23)
 ### Breaking changes

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -162,6 +162,12 @@
                       "--format" "quiet" "--fail-level" "fatal"))
     (ruby-syntax-tree . ("apheleia-from-project-root"
                          ".streerc" "stree" "format" filepath))
+    (ruff-isort . ("ruff" "chech"
+                   "-n"
+                   "--select" "I"
+                   "--fix" "--fix-only"
+                   "--stdin-filename" filepath
+                   "-"))
     (ruff . ("ruff" "format"
              "--silent"
              (apheleia-formatters-fill-column "--line-length")
@@ -437,8 +443,8 @@ and then write the formatted output back to the remote machine. Note some
 features of `apheleia' (such as `file' in `apheleia-formatters') is not
 compatible with this option and formatters relying on them will crash."
   :type '(choice (const :tag "Run the formatter on the local machine" local)
-                 (const :tag "Run the formatter on the remote machine" remote)
-                 (const :tag "Disable formatting for remote buffers" cancel))
+          (const :tag "Run the formatter on the remote machine" remote)
+          (const :tag "Disable formatting for remote buffers" cancel))
   :group 'apheleia)
 
 (defvar-local apheleia--current-process nil

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -162,17 +162,17 @@
                       "--format" "quiet" "--fail-level" "fatal"))
     (ruby-syntax-tree . ("apheleia-from-project-root"
                          ".streerc" "stree" "format" filepath))
-    (ruff-isort . ("ruff" "chech"
-                   "-n"
-                   "--select" "I"
-                   "--fix" "--fix-only"
-                   "--stdin-filename" filepath
-                   "-"))
     (ruff . ("ruff" "format"
              "--silent"
              (apheleia-formatters-fill-column "--line-length")
              "--stdin-filename" filepath
              "-"))
+    (ruff-isort . ("ruff" "check"
+                   "-n"
+                   "--select" "I"
+                   "--fix" "--fix-only"
+                   "--stdin-filename" filepath
+                   "-"))
     (shfmt . ("shfmt"
               "-filename" filepath
               "-ln" (cl-case (bound-and-true-p sh-shell)

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -443,8 +443,8 @@ and then write the formatted output back to the remote machine. Note some
 features of `apheleia' (such as `file' in `apheleia-formatters') is not
 compatible with this option and formatters relying on them will crash."
   :type '(choice (const :tag "Run the formatter on the local machine" local)
-          (const :tag "Run the formatter on the remote machine" remote)
-          (const :tag "Disable formatting for remote buffers" cancel))
+                 (const :tag "Run the formatter on the remote machine" remote)
+                 (const :tag "Disable formatting for remote buffers" cancel))
   :group 'apheleia)
 
 (defvar-local apheleia--current-process nil

--- a/test/formatters/installers/ruff-isort.bash
+++ b/test/formatters/installers/ruff-isort.bash
@@ -1,0 +1,2 @@
+apt-get install -y python3-pip
+pip install ruff

--- a/test/formatters/samplecode/ruff-isort/in.py
+++ b/test/formatters/samplecode/ruff-isort/in.py
@@ -1,0 +1,20 @@
+from my_lib import Object
+
+import os
+
+from my_lib import Object3
+
+from my_lib import Object2
+
+import sys
+
+from third_party import lib15, lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9, lib10, lib11, lib12, lib13, lib14
+
+import sys
+
+from __future__ import absolute_import
+
+from third_party import lib3
+
+print("Hey")
+print("yo")

--- a/test/formatters/samplecode/ruff-isort/out.py
+++ b/test/formatters/samplecode/ruff-isort/out.py
@@ -1,0 +1,11 @@
+from __future__ import absolute_import
+
+import os
+import sys
+
+from my_lib import Object, Object2, Object3
+from third_party import (lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9,
+                         lib10, lib11, lib12, lib13, lib14, lib15)
+
+print("Hey")
+print("yo")

--- a/test/formatters/samplecode/ruff-isort/out.py
+++ b/test/formatters/samplecode/ruff-isort/out.py
@@ -4,8 +4,23 @@ import os
 import sys
 
 from my_lib import Object, Object2, Object3
-from third_party import (lib1, lib2, lib3, lib4, lib5, lib6, lib7, lib8, lib9,
-                         lib10, lib11, lib12, lib13, lib14, lib15)
+from third_party import (
+    lib1,
+    lib2,
+    lib3,
+    lib4,
+    lib5,
+    lib6,
+    lib7,
+    lib8,
+    lib9,
+    lib10,
+    lib11,
+    lib12,
+    lib13,
+    lib14,
+    lib15,
+)
 
 print("Hey")
 print("yo")


### PR DESCRIPTION
`ruff` doesn't run isort as part of its format, so to maintain parity with the sort rules that black/isort offer, this is the ruff isort.