### PR TITLE
Add support for `treefmt`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog].
   clojurescript, edn files. ([#271])
 * Stylua is used now in `lua-ts-mode` as well as just `lua-mode`, by
   default ([#275]).
+* [`treefmt`](https://numtide.github.io/treefmt) for project configured formatters ([#280]).
 
 ### Bugs fixed
 * Apheleia sometimes failed to determine indent level from Emacs

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -185,6 +185,7 @@
     (stylua . ("stylua" "-"))
     (rustfmt . ("rustfmt" "--quiet" "--emit" "stdout"))
     (terraform . ("terraform" "fmt" "-"))
+    (treefmt . ("treefmt" "--stdin" filepath))
     (xmllint . ("xmllint" "--format" "-"))
     (yapf . ("yapf"))
     (yq-csv . ("yq" "--prettyPrint" "--no-colors"

--- a/test/formatters/installers/treefmt.bash
+++ b/test/formatters/installers/treefmt.bash
@@ -1,0 +1,11 @@
+ver="$(latest_release numtide/treefmt)"
+
+wget "https://github.com/numtide/treefmt/releases/download/${ver}/treefmt-x86_64-unknown-linux-gnu.tar.gz" -O - | tar -C /usr/local/bin -xz
+chmod +x /usr/local/bin/treefmt
+
+apt-get install -y rustfmt
+cat <<EOT >> /tmp/treefmt.toml
+[formatter.rust]
+command = "rustfmt"
+includes = ["*.rs"]
+EOT

--- a/test/formatters/samplecode/treefmt/in.rs
+++ b/test/formatters/samplecode/treefmt/in.rs
@@ -1,0 +1,12 @@
+fn foo() {
+    println!("a");
+}
+
+
+
+fn bar() {
+    println!("b");
+
+
+    println!("c");
+}

--- a/test/formatters/samplecode/treefmt/out.rs
+++ b/test/formatters/samplecode/treefmt/out.rs
@@ -1,0 +1,9 @@
+fn foo() {
+    println!("a");
+}
+
+fn bar() {
+    println!("b");
+
+    println!("c");
+}


### PR DESCRIPTION
This formatter is formatting via [treefmt](https://numtide.github.io/treefmt). This is useful if the project is configuring formatters for the project and you don't have to replicate this logic within Emacs, but instead utilize treefmt directly.

To do that you can set the `apheleia-formatter` to `treefmt` within the projects `.dir-locals.el`.

I noticed there are tests for this, since treefmt could technically format anything, I went with treefmt formatting rust code. It also relies on having a `treefmt.toml` in the project folder, so had to add that as well in the tests.
<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
