### PR TITLE
add support for pyang

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,10 @@ The format is based on [Keep a Changelog].
   clojurescript, edn files. ([#271])
 * Stylua is used now in `lua-ts-mode` as well as just `lua-mode`, by
   default ([#275]).
-* [`treefmt`](https://numtide.github.io/treefmt) for project configured formatters ([#280]).
+* [`treefmt`](https://numtide.github.io/treefmt) for project
+  configured formatters ([#280]).
+* [`pyang`](https://github.com/mbj4668/pyang) for
+  [YANG](https://www.rfc-editor.org/rfc/rfc7950.html) ([#282]).
 
 ### Bugs fixed
 * Apheleia sometimes failed to determine indent level from Emacs
@@ -53,6 +56,7 @@ The format is based on [Keep a Changelog].
 [#274]: https://github.com/radian-software/apheleia/issues/274
 [#275]: https://github.com/radian-software/apheleia/pull/275
 [#279]: https://github.com/radian-software/apheleia/pull/279
+[#282]: https://github.com/radian-software/apheleia/pull/282
 
 ## 4.0 (released 2023-11-23)
 ### Breaking changes

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -150,6 +150,7 @@
         "--parser=yaml"
         (apheleia-formatters-js-indent "--use-tabs" "--tab-width")))
     (purs-tidy . ("apheleia-npx" "purs-tidy" "format"))
+    (pyang . ("pyang" "--ignore-errors" "-f" "yang"))
     (robotidy . ("robotidy" "--no-color" "-"
                  (apheleia-formatters-indent nil "--indent")
                  (apheleia-formatters-fill-column "--line-length")))
@@ -370,7 +371,8 @@ rather than using this system."
     (typescript-ts-mode . prettier-typescript)
     (web-mode . prettier)
     (yaml-mode . prettier-yaml)
-    (yaml-ts-mode . prettier-yaml))
+    (yaml-ts-mode . prettier-yaml)
+    (yang-mode . pyang))
   "Alist mapping major mode names to formatters to use in those modes.
 This determines what formatter to use in buffers without a
 setting for `apheleia-formatter'. The keys are major mode

--- a/test/formatters/installers/pyang.bash
+++ b/test/formatters/installers/pyang.bash
@@ -1,0 +1,2 @@
+apt-get install -y python3-pip
+pip install pyang

--- a/test/formatters/samplecode/pyang/in.yang
+++ b/test/formatters/samplecode/pyang/in.yang
@@ -1,0 +1,10 @@
+module in { namespace "http://com/in/in";
+  prefix 
+    in       ;
+
+  list example { key "name";
+    leaf name {
+type string;   
+}
+          }  
+}

--- a/test/formatters/samplecode/pyang/out.yang
+++ b/test/formatters/samplecode/pyang/out.yang
@@ -1,0 +1,11 @@
+module in {
+  namespace "http://com/in/in";
+  prefix in;
+
+  list example {
+    key "name";
+    leaf name {
+      type string;
+    }
+  }
+}


### PR DESCRIPTION
Hi, 


pyang (https://github.com/mbj4668/pyang) is a YANG validator, transformator and code generator, written in python. YANG (RFC 7950) is a data modeling language for NETCONF (RFC 6241), developed by the IETF NETMOD WG. This formatter provides support for Emacs yang-mode.


