### PR TITLE
Update `apheleia-indent-lisp-buffer` to respect local variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Enhancements
+### Formatters
+### Bugs fixed
+* `apheleia-indent-lisp-buffer` updated to apply local variables after
+  calling major-mode. Also includes setting for `indent-tabs-mode` ([#286]).
+
+[#286]: https://github.com/radian-software/apheleia/pull/286
+
 ## 4.1 (released 2024-02-25)
 ### Enhancements
 * Use `perltidy` as default formatter for `cperl-mode` ([#260]).

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -1095,11 +1095,13 @@ transformation.
 For more implementation detail, see
 `apheleia--run-formatter-function'."
   (with-current-buffer scratch
+    (funcall (with-current-buffer buffer major-mode))
     (setq-local indent-line-function
                 (buffer-local-value 'indent-line-function buffer))
     (setq-local lisp-indent-function
-                (buffer-local-value 'lisp-indent-function buffer))
-    (funcall (with-current-buffer buffer major-mode))
+		(buffer-local-value 'lisp-indent-function buffer))
+    (setq-local indent-tabs-mode
+                (buffer-local-value 'indent-tabs-mode buffer))
     (goto-char (point-min))
     (let ((inhibit-message t)
           (message-log-max nil))


### PR DESCRIPTION
I ran into some issues using apheleia while contributing to a project
that works with `indent-tabs-mode` disabled. This led to this slight
modification of `apheleia-indent-lisp-buffer`

This allows for any local values for `indent-line-function`,
`lisp-indent-function` to be carried over when
formatting. Additionally, added `indent-tabs-mode` in order to
prevent adding tabs when unwanted.

If there is any additional documentation you would like me to provide,
let me know and I can update.
-------

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->