### PR TITLE
Parse shebangs on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@ The format is based on [Keep a Changelog].
 ### Bugs fixed
 * `apheleia-indent-lisp-buffer` updated to apply local variables after
   calling major-mode. Also includes setting for `indent-tabs-mode` ([#286]).
+* [Formatter scripts](scripts/formatters) will now work on Windows if Emacs
+  can find the executable defined in the shebang.
 
 [#286]: https://github.com/radian-software/apheleia/pull/286
+[#285]: https://github.com/radian-software/apheleia/issues/285
 
 ## 4.1 (released 2024-02-25)
 ### Enhancements


### PR DESCRIPTION
Parses the shebang from formatter scripts on Windows, and inserts the binary in to the command. This fixes https://github.com/radian-software/apheleia/issues/285. 
Please let me know if there is still something that need more work, thanks.

One minor issue I noticed is that errors will now get logged to `*aphleia-bash-log*` instead of `*apheleia-npx-log*`.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
