### PR TITLE
Update rubocop command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Formatters
+* [`rubocop`](https://github.com/rubocop/rubocop) changed to use `--autocorrect` instead of deprecated `--auto-correct` ([#316]).
+
+[#316]: https://github.com/radian-software/apheleia/pull/316
+
 ## 4.2 (released 2024-08-03)
 ### Changes
 * Custom Emacs Lisp formatting functions have the option to report an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### Formatters
-* [`rubocop`](https://github.com/rubocop/rubocop) changed to use `--autocorrect` instead of deprecated `--auto-correct` ([#316]).
+* [`rubocop`](https://github.com/rubocop/rubocop) changed to use `-a` instead of deprecated `--auto-correct` ([#316]).
 
 [#316]: https://github.com/radian-software/apheleia/pull/316
 

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -158,7 +158,7 @@
     (python3-json
      . ("python3" "-m" "json.tool"
         (apheleia-formatters-indent "--tab" "--indent")))
-    (rubocop . ("rubocop" "--stdin" filepath "--autocorrect"
+    (rubocop . ("rubocop" "--stdin" filepath "-a"
                 "--stderr" "--format" "quiet" "--fail-level" "fatal"))
     (ruby-standard . ("standardrb" "--stdin" filepath "--fix" "--stderr"
                       "--format" "quiet" "--fail-level" "fatal"))

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -158,7 +158,7 @@
     (python3-json
      . ("python3" "-m" "json.tool"
         (apheleia-formatters-indent "--tab" "--indent")))
-    (rubocop . ("rubocop" "--stdin" filepath "--auto-correct"
+    (rubocop . ("rubocop" "--stdin" filepath "--autocorrect"
                 "--stderr" "--format" "quiet" "--fail-level" "fatal"))
     (ruby-standard . ("standardrb" "--stdin" filepath "--fix" "--stderr"
                       "--format" "quiet" "--fail-level" "fatal"))


### PR DESCRIPTION
`--auto-correct` got deprecated in https://github.com/rubocop/rubocop/commit/aabdf0acf5ed729daf20506475d5629bfffb1890
