### PR TITLE
mix needs to use --stdin-filename to support non-elixir files like `.heex`

### DIFF
--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -90,8 +90,8 @@
     (lisp-indent . apheleia-indent-lisp-buffer)
     (ktlint . ("ktlint" "--log-level=none" "--stdin" "-F" "-"))
     (latexindent . ("latexindent" "--logfile=/dev/null"))
-    (mix-format . ("apheleia-from-project-root"
-                   ".formatter.exs" "mix" "format" "-"))
+    (mix-format . ("apheleia-from-project-root" ".formatter.exs"
+                   "mix" "format" "--stdin-filename" filepath "-"))
     (nixfmt . ("nixfmt"))
     (ocamlformat . ("ocamlformat" "-" "--name" filepath
                     "--enable-outside-detected-project"))
@@ -470,8 +470,8 @@ and then write the formatted output back to the remote machine. Note some
 features of `apheleia' (such as `file' in `apheleia-formatters') is not
 compatible with this option and formatters relying on them will crash."
   :type '(choice (const :tag "Run the formatter on the local machine" local)
-                 (const :tag "Run the formatter on the remote machine" remote)
-                 (const :tag "Disable formatting for remote buffers" cancel))
+          (const :tag "Run the formatter on the remote machine" remote)
+          (const :tag "Disable formatting for remote buffers" cancel))
   :group 'apheleia)
 
 (defvar-local apheleia--current-process nil


### PR DESCRIPTION
Hey, hope all is well. 

I was seeing errors formatting `.heex` files from `elixir-mode` in `*apheleia-apheleia-from-project-root-log*`:
```
$ apheleia-from-project-root .formatter.exs mix format -

mix format failed for stdin
** (SyntaxError) invalid syntax found on stdin.exs:1:1:
    error: syntax error before: '<'
    │
  1 │ <html lang="en" class="[scrollbar-gutter:stable]">
    │ ^
    │
    └─ stdin.exs:1:1
    (elixir 1.17.2) lib/code.ex:999: Code.format_string!/2
    (mix 1.17.2) lib/mix/tasks/format.ex:649: Mix.Tasks.Format.elixir_format/2
    (mix 1.17.2) lib/mix/tasks/format.ex:668: Mix.Tasks.Format.format_file/2
    (elixir 1.17.2) lib/task/supervised.ex:101: Task.Supervised.invoke_mfa/2
    (elixir 1.17.2) lib/task/supervised.ex:36: Task.Supervised.reply/4
```
Looking through the help page for `mix format`, I saw:
> `--stdin-filename' - path to the file being formatted on stdin. This is useful if you are using plugins to support custom filetypes such as .heex. Without passing this flag, it is assumed that the code being passed via stdin is valid Elixir code. Defaults to "stdin.exs".

This makes that change.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
