### PR TITLE
[#312] Fix Ormolu installation and invocation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,12 +25,16 @@ The format is based on [Keep a Changelog].
 * `apheleia-npx` was sometimes not able to find formatters in a Yarn
   PnP project if there was also a `node_modules` folder at the root of
   the project ([#301]).
+* Ormolu is now passed the `--stdin-input-file` argument, which has
+  become required ([#312]).
 
 ## Internal
 * Improvements to formatter test framework, it is now possible to
   write tests that have additional data files ([#301]).
 
 [#301]: https://github.com/radian-software/apheleia/pull/301
+[#306]: https://github.com/radian-software/apheleia/pull/306
+[#312]: https://github.com/radian-software/apheleia/issues/312
 [#313]: https://github.com/radian-software/apheleia/pull/313
 [#316]: https://github.com/radian-software/apheleia/pull/316
 [#317]: https://github.com/radian-software/apheleia/issues/317

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -96,7 +96,7 @@
     (ocamlformat . ("ocamlformat" "-" "--name" filepath
                     "--enable-outside-detected-project"))
     (ocp-indent . ("ocp-indent"))
-    (ormolu . ("ormolu"))
+    (ormolu . ("ormolu" "--stdin-input-file" filepath))
     (perltidy . ("perltidy" "--quiet" "--standard-error-output"
                  (apheleia-formatters-indent "-t" "-i")
                  (apheleia-formatters-fill-column "-l")))

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -320,7 +320,7 @@ rather than using this system."
     (go-mode . gofmt)
     (go-ts-mode . gofmt)
     (graphql-mode . prettier-graphql)
-    (haskell-mode . brittany)
+    (haskell-mode . ormolu)
     (hcl-mode . hclfmt)
     (html-mode . prettier-html)
     (html-ts-mode . prettier-html)

--- a/test/formatters/installers/ormolu.bash
+++ b/test/formatters/installers/ormolu.bash
@@ -1,3 +1,3 @@
-wget https://github.com/tweag/ormolu/releases/download/0.7.7.0/ormolu-x86_64-linux.zip -O ormolu.zip
-unzip -nv ormolu.zip
+wget -nv https://github.com/tweag/ormolu/releases/download/0.7.7.0/ormolu-x86_64-linux.zip -O ormolu.zip
+unzip ormolu.zip
 cp ormolu /usr/local/bin/

--- a/test/formatters/installers/ormolu.bash
+++ b/test/formatters/installers/ormolu.bash
@@ -1,4 +1,3 @@
-apt-get install -y ghc cabal-install
-cabal v2-update
-cabal v2-install ormolu --reorder-goals
-cp "${HOME}/.cabal/bin/ormolu" /usr/local/bin
+wget https://github.com/tweag/ormolu/releases/download/0.7.7.0/ormolu-x86_64-linux.zip -O ormolu.zip
+unzip -nv ormolu.zip
+cp ormolu /usr/local/bin/


### PR DESCRIPTION
Closes #312. The installation script was failing due to some Cabal bullshit that I don't even want to know the reason for, probably triggered by new package versions coming available, so I switched to upstream binaries. Applied the suggested fix from #312 for a new command-line option which has become required. Also set Ormolu as the default Haskell formatter instead of Brittany because that is what the Brittany dev recommends (see again #312).