### PR TITLE
Set MIX_QUIET=1 when running mix format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,6 @@ The format is based on [Keep a Changelog].
   output ([#326])
 * Beancount files are formatted without an error ([#309]).
 
-
 ## Internal
 * Improvements to formatter test framework, it is now possible to
   write tests that have additional data files ([#301]).
@@ -50,6 +49,7 @@ The format is based on [Keep a Changelog].
 [#316]: https://github.com/radian-software/apheleia/pull/316
 [#317]: https://github.com/radian-software/apheleia/issues/317
 [#319]: https://github.com/radian-software/apheleia/pull/319
+[#326]: https://github.com/radian-software/apheleia/pull/326
 
 ## 4.2 (released 2024-08-03)
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,10 @@ The format is based on [Keep a Changelog].
 * `mix format` is now passed the `--stdin-filename` argument which is
   required in some cases. The version of Mix is autodetected and this
   option is only passed when it is supported ([#319]).
+* `mix format` is now run with `MIX_QUIET` to supress compilation
+  output ([#326])
 * Beancount files are formatted without an error ([#309]).
+
 
 ## Internal
 * Improvements to formatter test framework, it is now possible to

--- a/scripts/formatters/apheleia-mix-format
+++ b/scripts/formatters/apheleia-mix-format
@@ -32,4 +32,4 @@ if [[ "${ver}" == "${higher_ver}" ]]; then
 fi
 args+=(-)
 
-exec "${args[@]}"
+MIX_QUIET=1 exec "${args[@]}"


### PR DESCRIPTION
With the current way of passing things to aphelia, sometimes compilation output gets added to the top of the formatted file.

This is because `mix format -` will actually still use [`Mix.Shell.info/1`](https://hexdocs.pm/mix/1.17.3/Mix.Shell.html#c:info/1) to output thing like:

```
==> module
Compiling 56 files (.ex)
```

However `info` messages can be silenced when setting `MIX_QUIET`. Docs: https://hexdocs.pm/mix/1.17.3/Mix.html#module-environment-variables

