### PR TITLE
Add zig fmt support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ The format is based on [Keep a Changelog].
 [#316]: https://github.com/radian-software/apheleia/pull/316
 [#317]: https://github.com/radian-software/apheleia/issues/317
 [#319]: https://github.com/radian-software/apheleia/pull/319
+[#327]: https://github.com/radian-software/apheleia/pull/327
 
 ## 4.2 (released 2024-08-03)
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog].
   instead of deprecated `--auto-correct` ([#316]).
 * `snakefmt` official formatter for
   [Snakemake](https://snakemake.readthedocs.io) ([#307]).
+* `zig fmt` official formatter for 
+  [zig](https://ziglang.org/) ([#327]).
 
 ### Bugs fixed
 * `apheleia-npx` would use an incorrect path for the Yarn PnP ESM

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -215,7 +215,8 @@
                (apheleia-formatters-indent nil "--indent")))
     (yq-yaml . ("yq" "--prettyPrint" "--no-colors" "--no-doc"
                 "--input-format" "yaml" "--output-format" "yaml"
-                (apheleia-formatters-indent nil "--indent"))))
+                (apheleia-formatters-indent nil "--indent")))
+    (zig-fmt . ("zig" "fmt" "--stdin")))
   "Alist of code formatting commands.
 The keys may be any symbols you want, and the values are shell
 commands, lists of strings and symbols, or a function symbol.
@@ -375,7 +376,9 @@ rather than using this system."
     (web-mode . prettier)
     (yaml-mode . prettier-yaml)
     (yaml-ts-mode . prettier-yaml)
-    (yang-mode . pyang))
+    (yang-mode . pyang)
+    (zig-mode . zig-fmt)
+    (zig-ts-mode . zig-fmt))
   "Alist mapping major mode names to formatters to use in those modes.
 This determines what formatter to use in buffers without a
 setting for `apheleia-formatter'. The keys are major mode

--- a/test/formatters/installers/zig-fmt.bash
+++ b/test/formatters/installers/zig-fmt.bash
@@ -1,0 +1,4 @@
+# https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager#ubuntu-snap
+wget "https://ziglang.org/download/0.13.0/zig-linux-x86_64-0.13.0.tar.xz" -O zig.tar.xz 
+tar -xf zig.tar.xz
+cp -r zig-linux-x86_64-0.13.0/* /usr/local/bin/

--- a/test/formatters/samplecode/zig-fmt/in.zig
+++ b/test/formatters/samplecode/zig-fmt/in.zig
@@ -1,0 +1,17 @@
+const Foo = struct {
+    a  : u32
+};
+
+const
+    Bar
+    = struct
+        {
+        b: u32
+        ,
+};
+
+pub fn
+thing(
+    a:
+    f32) f32 {    return a;
+}

--- a/test/formatters/samplecode/zig-fmt/out.zig
+++ b/test/formatters/samplecode/zig-fmt/out.zig
@@ -1,0 +1,9 @@
+const Foo = struct { a: u32 };
+
+const Bar = struct {
+    b: u32,
+};
+
+pub fn thing(a: f32) f32 {
+    return a;
+}


### PR DESCRIPTION
Add support for the zig programming language using `zig fmt` for `zig-mode` and `zig-ts-mode`.