### PR TITLE
Specify file type for buildifier explicitly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## 4.5 (unreleased)
+### Formatters
+* Format Bazel files according to their type
+
 ## 4.4 (released 2025-02-12)
 ### Bugs fixed
 * `$PATH` was not correctly respected for some remote executables ([#341]).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
-## 4.5 (unreleased)
+## Unreleased
 ### Formatters
 * Format Bazel files according to their type
 

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -34,7 +34,13 @@
               (apheleia-formatters-fill-column "--line-length")
               "-"))
     (brittany . ("brittany"))
-    (buildifier . ("buildifier"))
+    (buildifier . ("buildifier" "-type"
+                   (cond
+                    ((eq major-mode 'bazel-workspace-mode) "workspace")
+                    ((eq major-mode 'bazel-module-mode) "module")
+                    ((eq major-mode 'bazel-build-mode) "build")
+                    (t "auto")
+                    )))
     (biome . ("apheleia-npx" "biome" "format" "--stdin-file-path" filepath))
     (caddyfmt . ("caddy" "fmt" "-"))
     (clang-format . ("clang-format"


### PR DESCRIPTION
When formatting Bazel files, buildifier needs to know the concrete file
type which it usually deduces from the file name which is impossible
when operating on stdin.

For example, the order of load statements in a WORKSPACE file is
significant and re-ordering might break it.

