### PR TITLE
Fix patches moving a line to the top of the file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
 ## Unreleased
+### Bugs fixed
+* A formatter that moves a line to the top of the file would sometimes
+  place it as the second line instead ([#299]).
+
 ### Formatters
 * Format Bazel files according to their type
 

--- a/apheleia-rcs.el
+++ b/apheleia-rcs.el
@@ -100,7 +100,8 @@ contains the patch."
              ;; Account for the off-by-one error in the RCS patch spec
              ;; (namely, text is added *after* the line mentioned in
              ;; the patch).
-             (when (eq (alist-get 'command command) 'addition)
+             (when (and (eq (alist-get 'command command) 'addition)
+                        (> (alist-get 'start command) 0))
                (forward-line))
              (push `(marker . ,(point-marker)) command)
              (push command commands)

--- a/test/integration/apheleia-it.el
+++ b/test/integration/apheleia-it.el
@@ -226,3 +226,21 @@ exit 1
                    (lambda (&rest props)
                      (funcall callback (plist-get props :error))))))
            (expect "The slow brown fox jum|ped over the studious dog\n")))
+
+(apheleia-it-deftest supports-moving-line-to-the-top
+  "Running `apheleia-format-buffer' works when moving a line to the top"
+  :scripts `(("apheleia-it" .
+              ,(apheleia-it-script
+                :allowed-inputs
+                '(("line1\nline2\nline3\nline4" .
+                   "line4\nline1\nline2\nline3")))))
+  :formatters '((apheleia-it . ("apheleia-it")))
+  :steps '((insert "line1\n|line2\nline3\nline4")
+           (with-callback
+            callback
+            (eval (apheleia-format-buffer
+                   'apheleia-it nil
+                   :callback
+                   (lambda (&rest props)
+                     (funcall callback (plist-get props :error))))))
+           (expect "line4\nline1\n|line2\nline3")))


### PR DESCRIPTION
RCS patches containing a 'a0' instruction are not handled properly.
This pull request fixes the handling of 'a0' instructions and adds an integration test that fails otherwise.
Fixes #299.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
