### PR TITLE
Pass --text arg to diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ The format is based on [Keep a Changelog].
 ### Bugs fixed
 * A formatter that moves a line to the top of the file would sometimes
   place it as the second line instead ([#299]).
+* Fix invoking the diff command on Windows by always passing the --text
+flag
 
 ### Formatters
 * Format Bazel files according to their type

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -899,7 +899,10 @@ See `apheleia--run-formatters' for a description of REMOTE."
     (let ((ctx (apheleia-formatter--context)))
       (setf (apheleia-formatter--name ctx) nil ; Skip logging on failure
             (apheleia-formatter--arg1 ctx) "diff"
-            (apheleia-formatter--argv ctx) `("--rcs" "--strip-trailing-cr" "--"
+            (apheleia-formatter--argv ctx) `("--rcs"
+                                             "--strip-trailing-cr"
+                                             "--text"
+                                             "--"
                                              ,(or old-fname "-")
                                              ,(or new-fname "-"))
             (apheleia-formatter--remote ctx) remote


### PR DESCRIPTION
For some reason, GNU diff on Windows (from the MinGW project) fails to diff the file contents when passed over stdin unless the `--text` argument is passed. This argument forces diff to treat the inputs as text, and not binary.

To reproduce this error with Bash on Windows:

```
$ echo foo > foo
$ echo bar > bar
$ cat bar | diff.exe foo -
diff.exe: -: Invalid argument
$ cat bar | diff.exe --text foo -
1c1
< foo
---
> bar
```

It seems like this flag is harmless in this case, since Apheleia will always be used for diffing text files, and never binary files.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
