### PR TITLE
fix: use proper path separator on Windows

### DIFF
--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -571,9 +571,9 @@ NO-QUERY, and CONNECTION-TYPE."
   (ignore name noquery connection-type)
   (let* ((run-on-remote (and (eq apheleia-remote-algorithm 'remote)
                              remote))
-	 ;; Resolve the formatter executable's path to ensure it's
-	 ;; found
-	 (command (cons (executable-find (car command) run-on-remote) (cdr command)))
+         ;; Resolve the formatter executable's path to ensure it's
+         ;; found
+         (command (cons (executable-find (car command) run-on-remote) (cdr command)))
          (stderr-file (apheleia--make-temp-file run-on-remote "apheleia"))
          (args
           (append
@@ -1109,7 +1109,7 @@ purposes."
                 ;; for subprocesses of the proc we start.
                 (exec-path (cons script-dir exec-path))
                 (process-environment
-                 (cons (concat "PATH=" script-dir ":" (getenv "PATH"))
+                 (cons (concat "PATH=" script-dir path-separator (getenv "PATH"))
                        process-environment))
                 (ctx
                  (apheleia--formatter-context formatter command remote stdin)))


### PR DESCRIPTION
Fix the use of ":" as a separator for path elements. This is inappropriate for Windows.
There's a variable we can use instead: `path-separator`. 

I don't know exactly what breaks when the wrong separator is used. I do know that it's common for Windows paths to include ":" because that is the separator between the drive letter and the drive-local path. 
