### PR TITLE
Fix moving point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Bugs fixed
+* A formatter that adds indentation while point is at the end of the
+  line would sometimes leave point at the wrong position ([#362]).
+
 ## 4.4.1 (released 2025-05-13)
 ### Enhancements
 * Black will respect configuration in `pyproject.toml` when run via

--- a/apheleia-rcs.el
+++ b/apheleia-rcs.el
@@ -131,6 +131,7 @@ contains the patch."
                                 -1)
                              (alist-get 'start addition)))
                  (let ((text-start (alist-get 'marker deletion)))
+                   (goto-char text-start)
                    (forward-line (alist-get 'lines deletion))
                    (let ((text-end (point)))
                      (dolist (pos-spec pos-list)

--- a/test/integration/apheleia-it.el
+++ b/test/integration/apheleia-it.el
@@ -244,3 +244,22 @@ exit 1
                    (lambda (&rest props)
                      (funcall callback (plist-get props :error))))))
            (expect "line4\nline1\n|line2\nline3")))
+
+(apheleia-it-deftest supports-inserting-whitespace
+  "Running `apheleia-format-buffer' preserves point when inserting
+whitespace before point"
+  :scripts `(("apheleia-it" .
+              ,(apheleia-it-script
+                :allowed-inputs
+                '(("function main() {\na=\n  return 0\n}" .
+                   "function main() {\n  a=\n  return 0\n}")))))
+  :formatters '((apheleia-it . ("apheleia-it")))
+  :steps '((insert "function main() {\na=|\n  return 0\n}")
+           (with-callback
+            callback
+            (eval (apheleia-format-buffer
+                   'apheleia-it nil
+                   :callback
+                   (lambda (&rest props)
+                     (funcall callback (plist-get props :error))))))
+           (expect "function main() {\n  a=|\n  return 0\n}")))


### PR DESCRIPTION
When replacing text, calculate the cursor offset relative to the start of the replacement, not the end of the text-to-be-added.

* test/integration/apheleia-it.el (supports-inserting-whitespace): New test case
* apheleia-rcs.el (apheleia--apply-rcs-patch): Go to start of deletion text before calculating offsets
