### PR TITLE
add yaml-ts-mode to aphelia-formatters-indent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### Bugs fixed
+* aphelia-formatters-indent did not handle yaml-ts-mode; added with
+  same behaviour as yaml-mode
 * A formatter that adds indentation while point is at the end of the
   line would sometimes leave point at the wrong position ([#362]).
 ### Formatters

--- a/apheleia-utils.el
+++ b/apheleia-utils.el
@@ -61,7 +61,8 @@ always returns nil to defer to the formatter."
               (tsx-ts-mode 'typescript-ts-mode-indent-offset)
               (typescript-mode 'typescript-indent-level)
               (typescript-ts-mode 'typescript-ts-mode-indent-offset)
-              (yaml-mode 'yaml-indent-offset))))
+              (yaml-mode 'yaml-indent-offset)
+              (yaml-ts-mode 'yaml-indent-offset))))
 
     (when-let ((indent (and indent-var
                             (boundp indent-var)


### PR DESCRIPTION
Trivial change - other modes include `-ts-mode` variants, but not yaml.

This fix is confirmed to work for me, taking the indent level from `yaml-indent-offset`.
