### PR TITLE
Add support for oxfmt formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,14 @@ The format is based on [Keep a Changelog].
 * `bibtex-reformat` for BibTeX files.
 * `rubocop` changed to use `--force-exclusion` to obey exclusions in config
   files ([#380]).
+* [oxfmt](https://oxc.rs/docs/guide/usage/formatter) for JavaScript and
+  TypeScript files ([#382]).
 
 ### Bugs fixed
 * `shfmt` did not work with `apheleia-formatters-respect-indent-level`
 
 [#380]: https://github.com/radian-software/apheleia/pull/380
+[#382]: https://github.com/radian-software/apheleia/pull/382
 
 ## 4.4.2 (released 2025-11-21)
 ### Bugs fixed

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -112,6 +112,7 @@
                     "--enable-outside-detected-project"))
     (ocp-indent . ("ocp-indent"))
     (ormolu . ("ormolu" "--stdin-input-file" filepath))
+    (oxfmt . ("apheleia-npx" "oxfmt" inplace))
     (perltidy . ("perltidy" "--quiet" "--standard-error-output"
                  (apheleia-formatters-indent "-t" "-i")
                  (apheleia-formatters-fill-column "-l")))

--- a/test/formatters/installers/oxfmt.bash
+++ b/test/formatters/installers/oxfmt.bash
@@ -1,0 +1,1 @@
+npm install -g oxfmt

--- a/test/formatters/samplecode/oxfmt/in.js
+++ b/test/formatters/samplecode/oxfmt/in.js
@@ -1,0 +1,4 @@
+function HelloWorld({greeting = "hello", greeted = '"World"', silent = false, onMouseOver,}) {
+
+  if(!greeting){return null};
+  }

--- a/test/formatters/samplecode/oxfmt/in.ts
+++ b/test/formatters/samplecode/oxfmt/in.ts
@@ -1,0 +1,1 @@
+interface GreetingSettings{greeting: string; duration?: number; color?: string;}declare function greet(setting: GreetingSettings): void;

--- a/test/formatters/samplecode/oxfmt/out.js
+++ b/test/formatters/samplecode/oxfmt/out.js
@@ -1,0 +1,5 @@
+function HelloWorld({ greeting = "hello", greeted = '"World"', silent = false, onMouseOver }) {
+  if (!greeting) {
+    return null;
+  }
+}

--- a/test/formatters/samplecode/oxfmt/out.ts
+++ b/test/formatters/samplecode/oxfmt/out.ts
@@ -1,0 +1,6 @@
+interface GreetingSettings {
+  greeting: string;
+  duration?: number;
+  color?: string;
+}
+declare function greet(setting: GreetingSettings): void;


### PR DESCRIPTION
## Summary

- Add oxfmt (Oxc Formatter) as a new formatter option for JavaScript and TypeScript files

## Details

[Oxfmt](https://oxc.rs/docs/guide/usage/formatter) is a Rust-powered, Prettier-compatible code formatter from the Oxc project. It's currently in alpha but offers significant performance improvements (30x+ faster than Prettier).

Key points:
- Uses `inplace` mode since oxfmt doesn't support stdin/stdout
- Works with all common JS/TS extensions (.js, .jsx, .mjs, .cjs, .ts, .tsx, .mts)
- Not added to `apheleia-mode-alist` - users can opt-in by setting `apheleia-formatter` to `oxfmt`
- Defaults are already sensible: 2-space indent, printWidth 100, no tabs

Example usage:
```elisp
(setf (alist-get 'oxfmt apheleia-formatters)
      '("apheleia-npx" "oxfmt" inplace))

;; To use for JS/TS files:
(setq-default apheleia-formatter 'oxfmt)
;; Or per-mode:
(setf (alist-get 'typescript-ts-mode apheleia-mode-alist) 'oxfmt)
```