### PR TITLE
Remove --no-doc argument from yq-yaml formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog].
 
 ## Unreleased
 ### Formatters
+* Removed `--no-doc` argument from yq-yaml to avoid breaking
+  multi-document yaml files ([#386]).
 * Use clang-format for formatting Objective-C/C++ files ([#378]).
 * `bibtex-reformat` for BibTeX files.
 * `rubocop` changed to use `--force-exclusion` to obey exclusions in config

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -238,7 +238,7 @@
     (yq-xml . ("yq" "--prettyPrint" "--no-colors"
                "--input-format" "xml" "--output-format" "xml"
                (apheleia-formatters-indent nil "--indent")))
-    (yq-yaml . ("yq" "--prettyPrint" "--no-colors" "--no-doc"
+    (yq-yaml . ("yq" "--prettyPrint" "--no-colors"
                 "--input-format" "yaml" "--output-format" "yaml"
                 (apheleia-formatters-indent nil "--indent")))
     (zig-fmt . ("zig" "fmt" "--stdin")))

--- a/test/formatters/samplecode/yq-yaml/out.yml
+++ b/test/formatters/samplecode/yq-yaml/out.yml
@@ -1,3 +1,4 @@
+---
 - hosts: all
   tasks:
     - name: Get software for apt repository management.

--- a/test/formatters/samplecode/yq-yaml/test-dont-add-docsep/in.yml
+++ b/test/formatters/samplecode/yq-yaml/test-dont-add-docsep/in.yml
@@ -1,0 +1,12 @@
+doc: v1
+meta:
+  title:     t1
+  sub:
+    - sub1:    42
+      sub2: 3333
+doc: v1
+meta:
+  title: t2
+  sub:  
+    - sub1: 43
+      sub2:    4444

--- a/test/formatters/samplecode/yq-yaml/test-dont-add-docsep/out.yml
+++ b/test/formatters/samplecode/yq-yaml/test-dont-add-docsep/out.yml
@@ -1,0 +1,12 @@
+doc: v1
+meta:
+  title: t1
+  sub:
+    - sub1: 42
+      sub2: 3333
+doc: v1
+meta:
+  title: t2
+  sub:
+    - sub1: 43
+      sub2: 4444


### PR DESCRIPTION
The --no-doc argument removes existing document separators (---) from yaml files. It is perfectly valid and common practice to use multiple documents within a single file, e.g. in the kubernetes universe. Formatting such files with --no-doc breaks their validity.

See also the prettier-yaml test, which preserves the document separator, too.