### PR TITLE
fix: support for gdiff in UNIX-like systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,14 @@
 All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
+## Unreleased
+### Enhancements
+
+* Better support for BSD OSes using `gdiff` for RCS formatting, 
+  fallback to `diff`, which is the default GNU utility in Linux ([#388]).
+
+[#388]: https://github.com/radian-software/apheleia/pull/388
+
 ## 4.4.3 (released 2026-02-21)
 ### Formatters
 * Removed `--no-doc` argument from yq-yaml to avoid breaking

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -938,7 +938,10 @@ See `apheleia--run-formatters' for a description of REMOTE."
 
     (let ((ctx (apheleia-formatter--context)))
       (setf (apheleia-formatter--name ctx) nil ; Skip logging on failure
-            (apheleia-formatter--arg1 ctx) "diff"
+            (apheleia-formatter--arg1 ctx)
+            ;; Search gdiff in PATH, else use diff, useful for BSD
+            (if (executable-find "gdiff") "gdiff"
+              "diff")
             (apheleia-formatter--argv ctx) `("--rcs"
                                              "--strip-trailing-cr"
                                              "--text"


### PR DESCRIPTION
Hi!

In OpenBSD and  FreeBSD, `diff` don't have support for `--rcs`. In these cases, we need to use `gdiff` or `GNU diff` for this support. 

This change, fix the use of `diff `or `gdiff` for these OSes and make apheleia work.