### PR TITLE
OCaml: Add neocaml modes for ocamlformat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ The format is based on [Keep a Changelog].
 ## Unreleased
 ### Enhancements
 
-* Better support for BSD OSes using `gdiff` for RCS formatting, 
+* Ocamlformat is now used in `neocaml-mode` and `neocaml-interface-mode`
+  in addition to `tuareg-mode`
+  ([#389]).
+
+* Better support for BSD OSes using `gdiff` for RCS formatting,
   fallback to `diff`, which is the default GNU utility in Linux ([#388]).
 
 [#388]: https://github.com/radian-software/apheleia/pull/388
+[#389]: https://github.com/radian-software/apheleia/pull/389
 
 ## 4.4.3 (released 2026-02-21)
 ### Formatters

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -380,6 +380,8 @@ rather than using this system."
     ;; markdown code in so many different ways and we don't want to
     ;; try imposing a standard by default
     (nasm-mode . asmfmt)
+    (neocaml-interface-mode . ocamlformat)
+    (neocaml-mode . ocamlformat)
     (nix-mode . nixfmt)
     (nix-ts-mode . nixfmt)
     (nomad-mode . nomad)


### PR DESCRIPTION
Add neocaml-mode and neocaml-interface-mode to the list of modes that can be formatted with ocamlformat