### PR TITLE
Add OpenTofu, use by default for Terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog].
 
 ## Unreleased
+### Changes
+
+* OpenTofu has been added as a formatter, and is now used instead of
+  Terraform to format `.tf` files, by default ([#391]).
+
 ### Enhancements
 
 * Ocamlformat is now used in `neocaml-mode` and `neocaml-interface-mode`
@@ -15,6 +20,7 @@ The format is based on [Keep a Changelog].
 
 [#388]: https://github.com/radian-software/apheleia/pull/388
 [#389]: https://github.com/radian-software/apheleia/pull/389
+[#391]: https://github.com/radian-software/apheleia/pull/391
 
 ## 4.4.3 (released 2026-02-21)
 ### Formatters

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -112,6 +112,7 @@
                     "--enable-outside-detected-project"))
     (ocp-indent . ("ocp-indent"))
     (ormolu . ("ormolu" "--stdin-input-file" filepath))
+    (opentofu . ("tofu" "fmt" "-"))
     (oxfmt . ("apheleia-npx" "oxfmt" inplace))
     (perltidy . ("perltidy" "--quiet" "--standard-error-output"
                  (apheleia-formatters-indent "-t" "-i")
@@ -403,7 +404,7 @@ rather than using this system."
     (scss-mode . prettier-scss)
     (sql-mode . pgformatter)
     (svelte-mode . prettier-svelte)
-    (terraform-mode . terraform)
+    (terraform-mode . opentofu)
     (TeX-latex-mode . latexindent)
     (TeX-mode . latexindent)
     (toml-ts-mode . taplo)

--- a/test/formatters/installers/opentofu.bash
+++ b/test/formatters/installers/opentofu.bash
@@ -1,0 +1,7 @@
+curl -fsSL https://get.opentofu.org/opentofu.gpg -o /etc/apt/keyrings/opentofu.gpg
+curl -fsSL https://packages.opentofu.org/opentofu/tofu/gpgkey | gpg --no-tty --batch --dearmor -o /etc/apt/keyrings/opentofu-repo.gpg
+
+echo "deb [signed-by=/etc/apt/keyrings/opentofu.gpg,/etc/apt/keyrings/opentofu-repo.gpg] https://packages.opentofu.org/opentofu/tofu/any/ any main" > /etc/apt/sources.list.d/opentofu.list
+
+apt-get update
+apt-get install -y tofu

--- a/test/formatters/samplecode/opentofu/in.tf
+++ b/test/formatters/samplecode/opentofu/in.tf
@@ -1,0 +1,6 @@
+    resource "google_sql_user" "user" {
+  name              = "camunda"
+  instance =google_sql_database_instance.camunda-db.name
+
+            password       ="futurice"
+      }

--- a/test/formatters/samplecode/opentofu/out.tf
+++ b/test/formatters/samplecode/opentofu/out.tf
@@ -1,0 +1,6 @@
+resource "google_sql_user" "user" {
+  name     = "camunda"
+  instance = google_sql_database_instance.camunda-db.name
+
+  password = "futurice"
+}


### PR DESCRIPTION
Seems fairly straightforward to me, Terraform is no longer open-source, OpenTofu is the compatible open-source successor, similar to the Redis/Valkey situation.

Of course, if someone still prefers to use Terraform instead, they can easily customize using:

```tf
(setf (alist-get 'terraform-mode apheleia-mode-alist) 'terraform)
```

We don't have a mechanism for allowing multiple formatters to be registered for the same major mode, where later ones could be used if earlier ones are not installed. That might be a nice addition.
