### PR TITLE
fix: sync lisp-indent-offset and lisp-body-indent in apheleia-indent-lisp-buffer

### DIFF
--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -534,8 +534,8 @@ and then write the formatted output back to the remote machine. Note some
 features of `apheleia' (such as `file' in `apheleia-formatters') is not
 compatible with this option and formatters relying on them will crash."
   :type '(choice (const :tag "Run the formatter on the local machine" local)
-                 (const :tag "Run the formatter on the remote machine" remote)
-                 (const :tag "Disable formatting for remote buffers" cancel))
+          (const :tag "Run the formatter on the remote machine" remote)
+          (const :tag "Disable formatting for remote buffers" cancel))
   :group 'apheleia)
 
 (defvar-local apheleia--current-process nil
@@ -1243,6 +1243,10 @@ For more implementation detail, see
                 (buffer-local-value 'lisp-indent-function buffer))
     (setq-local indent-tabs-mode
                 (buffer-local-value 'indent-tabs-mode buffer))
+    (setq-local lisp-indent-offset
+                (buffer-local-value 'lisp-indent-offset buffer))
+    (setq-local lisp-body-indent
+                (buffer-local-value 'lisp-body-indent buffer))
     (goto-char (point-min))
     (let ((inhibit-message t)
           (message-log-max nil))


### PR DESCRIPTION
`apheleia-indent-lisp-buffer` copies several buffer-local variables to the
scratch buffer before running `indent-region`, but `lisp-indent-offset` and
`lisp-body-indent` are missing. When either of these is set in the original
buffer, the scratch buffer falls back to different defaults, producing
indentation that disagrees with what `indent-region` would produce interactively.

Reproducer: with `lisp-indent-offset` set to 2, the following form

  (setopt
     lsp-inlay-hint-enable t
     lsp-log-io nil)

formats to one space of indentation instead of two.

Fix: sync `lisp-indent-offset` and `lisp-body-indent` from the original buffer
to the scratch buffer, the same way the existing code already does for
`indent-line-function`, `lisp-indent-function`, and `indent-tabs-mode`.