### PR TITLE
fix: sync lisp-indent-offset and lisp-body-indent in apheleia-indent-lisp-buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,11 +17,14 @@ The format is based on [Keep a Changelog].
 ### Bugs fixed
 * `shfmt` did not work with `apheleia-formatters-respect-indent-level`
 * `apheleia-npx` did return an error when formatter was missing
+* `lisp-indent` formatter did not respect `lisp-indent-offset` and
+  `lisp-body-offset` ([#393])
 
 [#378]: https://github.com/radian-software/apheleia/pull/378
 [#380]: https://github.com/radian-software/apheleia/pull/380
 [#382]: https://github.com/radian-software/apheleia/pull/382
 [#386]: https://github.com/radian-software/apheleia/pull/386
+[#393]: https://github.com/radian-software/apheleia/pull/393
 
 ## 4.4.2 (released 2025-11-21)
 ### Bugs fixed

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -1243,6 +1243,10 @@ For more implementation detail, see
                 (buffer-local-value 'lisp-indent-function buffer))
     (setq-local indent-tabs-mode
                 (buffer-local-value 'indent-tabs-mode buffer))
+    (setq-local lisp-indent-offset
+                (buffer-local-value 'lisp-indent-offset buffer))
+    (setq-local lisp-body-indent
+                (buffer-local-value 'lisp-body-indent buffer))
     (goto-char (point-min))
     (let ((inhibit-message t)
           (message-log-max nil))


### PR DESCRIPTION
apheleia-indent-lisp-buffer copies several buffer-local variables to the
scratch buffer before running indent-region, but lisp-indent-offset and
lisp-body-indent are missing. When either of these is set in the original
buffer, the scratch buffer falls back to different defaults, producing
indentation that disagrees with what indent-region would produce interactively.

Reproducer: with lisp-indent-offset set to 2, the following form

(setopt
lsp-inlay-hint-enable t
lsp-log-io nil)

formats to one space of indentation instead of two.

Fix: sync lisp-indent-offset and lisp-body-indent from the original buffer
to the scratch buffer, the same way the existing code already does for
indent-line-function, lisp-indent-function, and indent-tabs-mode.