### PR TITLE
Add sqlfluff formatter for SQL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ The format is based on [Keep a Changelog].
 * `sqlfluff` has been added as a formatter. It is not enabled by
   default; `pgformatter` remains the default for `sql-mode`. Set
   `apheleia-formatter` to `sqlfluff` to use it. A `.sqlfluff` config
-  file specifying the SQL dialect is required in the project.
+  file specifying the SQL dialect is required in the project
+  ([#395]).
 
 ### Enhancements
 
@@ -35,6 +36,7 @@ The format is based on [Keep a Changelog].
 [#389]: https://github.com/radian-software/apheleia/pull/389
 [#391]: https://github.com/radian-software/apheleia/pull/391
 [#394]: https://github.com/radian-software/apheleia/pull/394
+[#395]: https://github.com/radian-software/apheleia/pull/395
 
 ## 4.4.3 (released 2026-02-21)
 ### Formatters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on [Keep a Changelog].
 
 * A variant of `deno format` was added to support YAML files ([#394]).
 
+* `sqlfluff` has been added as a formatter. It is not enabled by
+  default; `pgformatter` remains the default for `sql-mode`. Set
+  `apheleia-formatter` to `sqlfluff` to use it. A `.sqlfluff` config
+  file specifying the SQL dialect is required in the project.
+
 ### Enhancements
 
 * Ocamlformat is now used in `neocaml-mode` and `neocaml-interface-mode`

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -216,6 +216,7 @@
     (snakefmt . ("snakefmt"
                  (apheleia-formatters-fill-column "--line-length")
                  "-"))
+    (sqlfluff . ("sqlfluff" "format" "--disable-progress-bar" "-"))
     (shfmt . ("shfmt"
               "-filename" filepath
               "-ln" (cl-case (bound-and-true-p sh-shell)

--- a/test/formatters/installers/sqlfluff.bash
+++ b/test/formatters/installers/sqlfluff.bash
@@ -1,0 +1,2 @@
+apt-get install -y python3-pip
+pip install sqlfluff

--- a/test/formatters/samplecode/sqlfluff/.sqlfluff
+++ b/test/formatters/samplecode/sqlfluff/.sqlfluff
@@ -1,0 +1,2 @@
+[sqlfluff]
+dialect = postgres

--- a/test/formatters/samplecode/sqlfluff/in.sql
+++ b/test/formatters/samplecode/sqlfluff/in.sql
@@ -1,0 +1,1 @@
+select id,name,email from users where id=1 and name='alice';

--- a/test/formatters/samplecode/sqlfluff/out.sql
+++ b/test/formatters/samplecode/sqlfluff/out.sql
@@ -1,0 +1,6 @@
+select
+    id,
+    name,
+    email
+from users
+where id = 1 and name = 'alice';


### PR DESCRIPTION
Add sqlfluff as an opt-in formatter.

Tested with `make fmt-build fmt-docker FORMATTERS=sqlfluff CMD='make fmt-test'`. 