### PR TITLE
fix(shfmt): do not pass -ln or --indent, to respect editorconfig

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
   pull_request: {}
+permissions: {}
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -21,5 +22,6 @@ jobs:
       - name: Run linters
         env:
           VERSION: ${{ matrix.emacs_version }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: >-
           make docker CMD="make unit integration lint lint-changelog"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,10 +20,16 @@ The format is based on [Keep a Changelog].
 * Recognize csharp, dockerfile and php ts-modes, apply same settings as
   for the corresponding non-ts modes ([#396]).
 
+### Bugs fixed
+
+* Do not pass any parser or printer options to shfmt. Doing so causes
+  .editorconfig configuration that might be in effect to be ignored
+  altogether ([#401]).
+
 [#396]: https://github.com/radian-software/apheleia/pull/396
 [#397]: https://github.com/radian-software/apheleia/pull/397
 [#398]: https://github.com/radian-software/apheleia/pull/398
-[#400]: https://github.com/radian-software/apheleia/pull/400
+[#402]: https://github.com/radian-software/apheleia/pull/402
 
 ## 4.5.0 (released 2026-05-25)
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog].
 ## Unreleased
 ### Changes
 
+* Apheleia no longer passes config options to shfmt based on Emacs
+  configuration, because shfmt has a behavior where doing so
+  completely erases all .editorconfig configuration, which is
+  relatively undesirable ([#402]).
+
+### New formatters
+
 * [Mago](https://mago.carthage.software) has been added as a PHP formatter.
   It is not enabled by default; `phpcs` remains the default for PHP
   modes ([#397]).
@@ -19,12 +26,6 @@ The format is based on [Keep a Changelog].
 
 * Recognize csharp, dockerfile and php ts-modes, apply same settings as
   for the corresponding non-ts modes ([#396]).
-
-### Bugs fixed
-
-* Do not pass any parser or printer options to shfmt. Doing so causes
-  .editorconfig configuration that might be in effect to be ignored
-  altogether ([#401]).
 
 [#396]: https://github.com/radian-software/apheleia/pull/396
 [#397]: https://github.com/radian-software/apheleia/pull/397

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -221,20 +221,9 @@
                  (apheleia-formatters-fill-column "--line-length")
                  "-"))
     (sqlfluff . ("sqlfluff" "format" "--disable-progress-bar" "-"))
-    (shfmt . ("shfmt"
-              "-filename" filepath
-              "-ln" (cl-case (bound-and-true-p sh-shell)
-                      (sh "posix")
-                      (t "bash"))
-              (when apheleia-formatters-respect-indent-level
-                (format
-                 "--indent=%d"
-                 (cond
-                  (indent-tabs-mode 0)
-                  ((boundp 'sh-basic-offset)
-                   sh-basic-offset)
-                  (t 4))))
-              "-"))
+    ;; Note: do not pass any parser or printer flags to shfmt,
+    ;; doing so causes editorconfig configuration to be bypassed altogether.
+    (shfmt . ("shfmt" "-filename" filepath "-"))
     (rufo . ("rufo" "--filename" filepath "--simple-exit"))
     (stylua . ("stylua" "-"))
     (rustfmt . ("rustfmt" "--quiet" "--emit" "stdout"))

--- a/test/formatters/Dockerfile
+++ b/test/formatters/Dockerfile
@@ -13,6 +13,6 @@ FROM common
 ARG FORMATTERS
 COPY install-formatters.bash /build/
 COPY installers /build/installers/
-RUN ./install-formatters.bash
+RUN --mount=type=secret,id=GITHUB_TOKEN,env=GITHUB_TOKEN ./install-formatters.bash
 
 WORKDIR /src

--- a/test/formatters/build-image.bash
+++ b/test/formatters/build-image.bash
@@ -30,4 +30,5 @@ fi
 
 exec "${docker[@]}" build . "${args[@]}"       \
      -t "apheleia-formatters:${TAG:-latest}"   \
-     --build-arg "FORMATTERS=${FORMATTERS:-}"
+     --build-arg "FORMATTERS=${FORMATTERS:-}"  \
+     --secret id=GITHUB_TOKEN,env=GITHUB_TOKEN

--- a/test/formatters/install-formatters.bash
+++ b/test/formatters/install-formatters.bash
@@ -28,7 +28,11 @@ mkdir /tmp/apheleia-work
 cd /tmp/apheleia-work
 
 latest_release() {
-    curl -fsSL "https://api.github.com/repos/$1/releases/latest" | jq -r .tag_name
+    local headers=()
+    if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+        headers+=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+    fi
+    curl -fsSL "${headers[@]}" "https://api.github.com/repos/$1/releases/latest" | jq -r .tag_name
 }
 
 echo >&2 "-- Will install ${#FORMATTERS[@]} formatter(s) --"


### PR DESCRIPTION
This might be a bit controversial, but without this, as it stands, there's no way to get apheleia uses of shfmt to honor projects editorconfigs (`-ln` is passed unconditionally). FWIW in my opinion shfmt's behavior is not great there, better would be to override only editorconfig settings by ones set on the cmdline, not all of them even if anything is passed. But it seems it's intentional in shfmt.

Ref https://github.com/mvdan/sh/blob/master/cmd/shfmt/shfmt.1.scd

> If any parser or printer flags are given to the tool, no EditorConfig formatting options will be used.

Users are better off using editorconfig to configure shfmt, so the configuration applies to all kinds of shfmt uses.

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
