### PR TITLE
Use taplo in conf-toml-mode, too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog].
 * Recognize csharp, dockerfile and php ts-modes, apply same settings as
   for the corresponding non-ts modes ([#396]).
 * [yq](https://mikefarah.gitbook.io/yq) is now used in `tsv-mode` ([#406]).
+* [taplo](https://taplo.tamasfe.dev/) is now used by default for TOML
+  also in `conf-toml-mode` ([#407]).
 
 [#396]: https://github.com/radian-software/apheleia/pull/396
 [#397]: https://github.com/radian-software/apheleia/pull/397
@@ -39,6 +41,7 @@ The format is based on [Keep a Changelog].
 [#403]: https://github.com/radian-software/apheleia/pull/403
 [#405]: https://github.com/radian-software/apheleia/pull/405
 [#406]: https://github.com/radian-software/apheleia/pull/406
+[#407]: https://github.com/radian-software/apheleia/pull/407
 
 ## 4.5.0 (released 2026-05-25)
 ### Changes

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -345,7 +345,7 @@ rather than using this system."
     (cmake-mode . cmake-format)
     (cmake-ts-mode . cmake-format)
     (common-lisp-mode . lisp-indent)
-    (conf-toml-mode . dprint)
+    (conf-toml-mode . taplo)
     (cperl-mode . perltidy)
     (crystal-mode . crystal-tool-format)
     (csharp-mode . csharpier)


### PR DESCRIPTION
For consistency with toml-ts-mode, and taplo instead of dprint because dprint might not have the TOML plugin installed, which is not handled that well at the moment.

Closes https://github.com/radian-software/apheleia/issues/404

<!--

To expedite the pull request process, please see the contributor guide
for my projects:

  <https://github.com/raxod502/contributor-guide>

-->
