### PR TITLE
Fix window scroll jump after line-neutral RCS patches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,12 @@ The format is based on [Keep a Changelog].
 * [taplo](https://taplo.tamasfe.dev/) is now used by default for TOML
   also in `conf-toml-mode` ([#407]).
 
+### Bugs fixed
+
+* Apheleia no longer scrolls the window after formatting when a
+  line-neutral change only moves point to the beginning of its line
+  ([#409]).
+
 [#396]: https://github.com/radian-software/apheleia/pull/396
 [#397]: https://github.com/radian-software/apheleia/pull/397
 [#398]: https://github.com/radian-software/apheleia/pull/398
@@ -47,6 +53,7 @@ The format is based on [Keep a Changelog].
 [#406]: https://github.com/radian-software/apheleia/pull/406
 [#407]: https://github.com/radian-software/apheleia/pull/407
 [#408]: https://github.com/radian-software/apheleia/pull/408
+[#409]: https://github.com/radian-software/apheleia/pull/409
 
 ## 4.5.0 (released 2026-05-25)
 ### Changes

--- a/apheleia-rcs.el
+++ b/apheleia-rcs.el
@@ -85,7 +85,10 @@ contains the patch."
       (dolist (w (get-buffer-window-list nil nil t))
         (push
          `(:type window-point :pos ,(window-point w) :window ,w) pos-list)
-        (push (cons w (count-lines (window-start w) (point)))
+        (push (list w (count-lines (window-start w) (point))
+                    (- (line-number-at-pos (point))
+                       (line-number-at-pos (window-start w)))
+                    (copy-marker (window-start w)))
               window-line-list)))
     (with-current-buffer patch-buffer
       (apheleia--map-rcs-patch
@@ -194,16 +197,23 @@ contains the patch."
     ;; Restore the scroll position of each window displaying the
     ;; buffer.
     (dolist (entry window-line-list)
-      (cl-destructuring-bind (w . old-window-line) entry
+      (cl-destructuring-bind
+          (w old-window-line old-window-line-distance old-window-start) entry
         (let ((new-window-line
-               (count-lines (window-start w) (point))))
+               (count-lines (window-start w) (point)))
+              (new-window-line-distance
+               (- (line-number-at-pos (point))
+                  (line-number-at-pos old-window-start))))
           (with-selected-window w
             ;; Sometimes if the text is less than a buffer long, and
             ;; we do a deletion, it might not be possible to keep the
             ;; vertical position of point the same by scrolling.
             ;; That's okay. We just go as far as we can.
             (ignore-errors
-              (scroll-down (- old-window-line new-window-line)))))))))
+              (if (= old-window-line-distance new-window-line-distance)
+                  (set-window-start w old-window-start)
+                (scroll-down (- old-window-line new-window-line)))))
+          (set-marker old-window-start nil))))))
 
 (provide 'apheleia-rcs)
 

--- a/test/unit/apheleia-unit-test.el
+++ b/test/unit/apheleia-unit-test.el
@@ -145,3 +145,31 @@
      ('html-mode "ok.blah" '(fmt-blah))
      ('html-mode "ok.blah.foobar" '(fmt-foobar))
      ('html-mode "ok.blah.foobaz" '(fmt-blah)))))
+
+(describe "apheleia--apply-rcs-patch"
+  (it "does not scroll when point moves to beginning of line"
+    (let ((content-buffer (generate-new-buffer " *apheleia-test-content*"))
+          (patch-buffer (generate-new-buffer " *apheleia-test-patch*")))
+      (unwind-protect
+          (progn
+            (with-current-buffer content-buffer
+              (dotimes (i 50)
+                (if (= i 20)
+                    (insert (format "    line %02d\n" i))
+                  (insert (format "line %02d\n" i))))
+              (switch-to-buffer content-buffer)
+              (goto-char (point-min))
+              (forward-line 10)
+              (set-window-start (selected-window) (point))
+              (goto-char (point-min))
+              (forward-line 20)
+              (forward-char 4))
+            (with-current-buffer patch-buffer
+              (insert "d21 1\na21 1\nline 20\n"))
+            (with-current-buffer content-buffer
+              (apheleia--apply-rcs-patch content-buffer patch-buffer)
+              (expect (line-number-at-pos (window-start)) :to-be 11)
+              (expect (line-number-at-pos) :to-be 21)
+              (expect (current-column) :to-be 0)))
+        (kill-buffer content-buffer)
+        (kill-buffer patch-buffer)))))


### PR DESCRIPTION
## Summary

Fix a scroll jump that can happen when applying an RCS patch changes
text around point without changing the point's vertical line position.

Apheleia restores scroll position by comparing the number of lines
between `window-start` and point before and after applying the patch.
For line-neutral replacements, such as removing leading whitespace
from the line containing point, Emacs can adjust `window-start` while
the replacement is applied. In that case, Apheleia may scroll even
though point did not move vertically relative to the original window
start.

This stores the original `window-start` marker and line distance. If
point is still the same number of lines from the original window start
after the patch, restore that window start directly; otherwise keep
the existing scroll adjustment behavior.

## Test

Added a unit test covering a one-line replacement where point moves
from an indented column to beginning of line.

Before the fix, the new test fails with `window-start` moving from
line 11 to line 9. With the fix, `make unit` passes.