### PR TITLE
Add formatter for slint files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ The format is based on [Keep a Changelog].
 * [dockerfmt](https://github.com/reteps/dockerfmt) has been added as a
   Dockerfile formatter. It is not enabled by default; `dprint` remains the
   default for Dockerfiles ([#410]).
+* [slint-lsp format](https://docs.slint.dev/latest/docs/slint/guide/tooling/manual-setup/#formatting-slint-files)
+  has been added as a Slint formatter ([#411]).
 
 ### Enhancements
 

--- a/apheleia-formatters.el
+++ b/apheleia-formatters.el
@@ -220,6 +220,7 @@
                    "--fix" "--fix-only"
                    "--stdin-filename" filepath
                    "-"))
+    (slint . ("slint-lsp" "format" filepath))
     (snakefmt . ("snakefmt"
                  (apheleia-formatters-fill-column "--line-length")
                  "-"))

--- a/test/formatters/installers/slint.bash
+++ b/test/formatters/installers/slint.bash
@@ -1,0 +1,9 @@
+# Following instructions from
+# https://docs.slint.dev/latest/docs/slint/guide/tooling/manual-setup/#from-pre-built-binaries-manual-download
+
+# slint-lsp requires the following libraries
+apt-get install -y libxkbcommon0 libinput10 libgbm1 libfontconfig1
+
+curl -LSf -o /tmp/slint-lsp.tar.gz https://github.com/slint-ui/slint/releases/latest/download/slint-lsp-x86_64-unknown-linux-gnu.tar.gz
+tar -zxvf /tmp/slint-lsp.tar.gz -C /tmp/
+mv /tmp/slint-lsp/slint-lsp /usr/local/bin

--- a/test/formatters/samplecode/slint/in.slint
+++ b/test/formatters/samplecode/slint/in.slint
@@ -1,0 +1,6 @@
+export component MainWindow inherits Window {
+      Text {
+      text: "hello world";
+        color: green;
+    }
+}

--- a/test/formatters/samplecode/slint/out.slint
+++ b/test/formatters/samplecode/slint/out.slint
@@ -1,0 +1,6 @@
+export component MainWindow inherits Window {
+    Text {
+        text: "hello world";
+        color: green;
+    }
+}


### PR DESCRIPTION
[slint-lsp] can format files. By default it takes a path and outputs the formatted file to standard out.

[slint-lsp]: https://docs.slint.dev/latest/docs/slint/guide/tooling/manual-setup/#formatting-slint-files
